### PR TITLE
feat: company member role system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { initializePaddle } from '@paddle/paddle-js'
 import { Signup } from './pages/auth/Signup'
 import { WorkerSignup } from './pages/auth/WorkerSignup'
+import { CompanyMemberSignup } from './pages/auth/CompanyMemberSignup'
 import { Login } from './pages/auth/Login'
 import { ForgotPassword } from './pages/auth/ForgotPassword'
 import { ResetPassword } from './pages/auth/ResetPassword'
@@ -38,6 +39,7 @@ import { AppConfiguration } from './components/AppConfiguration'
 import { GlobalModalOuterContextProvider, GlobalModal } from './components/UI/GlobalModal'
 import { GlobalSnackbarProvider } from './contexts/SnackbarContext'
 import { SubscriptionProvider } from './contexts/SubscriptionContext'
+import { CompanyRoleProvider } from './contexts/CompanyRoleContext'
 import { CurrencyProvider } from './contexts/CurrencyContext'
 import env from './config/env'
 import './App.css'
@@ -57,11 +59,13 @@ function App() {
         <Router>
           <CurrencyProvider>
           <SubscriptionProvider>
+          <CompanyRoleProvider>
             <AppConfiguration />
             <Routes>
             {/* Public routes - No layout */}
             <Route path="/signup" element={<Signup />} />
             <Route path="/signup/worker" element={<WorkerSignup />} />
+            <Route path="/signup/company-member" element={<CompanyMemberSignup />} />
             <Route path="/login" element={<Login />} />
             <Route path="/signin" element={<Login />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
@@ -107,6 +111,7 @@ function App() {
             <Route path="/" element={<Navigate to="/login" replace />} />
           </Routes>
             <GlobalModal />
+          </CompanyRoleProvider>
           </SubscriptionProvider>
           </CurrencyProvider>
         </Router>

--- a/src/contexts/CompanyRoleContext.tsx
+++ b/src/contexts/CompanyRoleContext.tsx
@@ -1,0 +1,109 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { authService } from '../services/api/auth';
+import { companyMemberService } from '../services/api/companyMember';
+import type { CompanyRole, MemberResponse } from '../services/api/companyMember';
+import { MemberResponseCompanyRoleEnum } from '../../workflow-api';
+import { getRoleFromToken, decodeJWT } from '../utils/jwt';
+
+export interface CompanyRoleContextValue {
+  companyRole: CompanyRole | null;
+  isLoading: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  canManageFinances: boolean;
+  canManageWorkers: boolean;
+  canInviteMembers: boolean;
+  canManageRoles: boolean;
+  canManageSubscription: boolean;
+  refresh: () => Promise<void>;
+}
+
+const CompanyRoleContext = createContext<CompanyRoleContextValue | undefined>(undefined);
+
+export const useCompanyRole = (): CompanyRoleContextValue => {
+  const ctx = useContext(CompanyRoleContext);
+  if (!ctx) throw new Error('useCompanyRole must be used within CompanyRoleProvider');
+  return ctx;
+};
+
+const EDIT_ROLES: CompanyRole[] = [
+  MemberResponseCompanyRoleEnum.CompanyAdmin,
+  MemberResponseCompanyRoleEnum.Manager,
+  MemberResponseCompanyRoleEnum.Editor,
+];
+const MANAGER_ROLES: CompanyRole[] = [
+  MemberResponseCompanyRoleEnum.CompanyAdmin,
+  MemberResponseCompanyRoleEnum.Manager,
+];
+
+export const CompanyRoleProvider = ({ children }: { children: ReactNode }) => {
+  const [companyRole, setCompanyRole] = useState<CompanyRole | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isCompanyUser = useCallback((): boolean => {
+    const token = authService.getAccessToken();
+    if (!token) return false;
+    const role = getRoleFromToken(token);
+    return role === 'ROLE_COMPANY' || role === 'COMPANY';
+  }, []);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!isCompanyUser()) return;
+    const token = authService.getAccessToken();
+    if (!token) return;
+
+    // JWT sub may be username (string) or userId (number string) depending on backend config
+    const payload = decodeJWT(token);
+    const sub = payload?.sub ?? null;
+
+    try {
+      const { data } = await companyMemberService.getMembers();
+      const members = data as MemberResponse[];
+
+      let me: MemberResponse | undefined;
+
+      // Try matching by username first (Spring Security default sub = username)
+      if (sub) {
+        me = members.find((m) => m.username === sub);
+      }
+
+      // Fall back to numeric userId if sub looks like a number
+      if (!me && sub) {
+        const numericId = parseInt(sub, 10);
+        if (!isNaN(numericId)) {
+          me = members.find((m) => m.userId === numericId);
+        }
+      }
+
+      if (me?.companyRole) setCompanyRole(me.companyRole);
+    } catch {
+      // silently fail
+    }
+  }, [isCompanyUser]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    refresh().finally(() => setIsLoading(false));
+  }, [refresh]);
+
+  const has = (roles: CompanyRole[]) => !!companyRole && roles.includes(companyRole);
+
+  return (
+    <CompanyRoleContext.Provider
+      value={{
+        companyRole,
+        isLoading,
+        canEdit: has(EDIT_ROLES),
+        canDelete: has(MANAGER_ROLES),
+        canManageFinances: has(MANAGER_ROLES),
+        canManageWorkers: has(MANAGER_ROLES),
+        canInviteMembers: has(MANAGER_ROLES),
+        canManageRoles: companyRole === MemberResponseCompanyRoleEnum.CompanyAdmin,
+        canManageSubscription: companyRole === MemberResponseCompanyRoleEnum.CompanyAdmin,
+        refresh,
+      }}
+    >
+      {children}
+    </CompanyRoleContext.Provider>
+  );
+};

--- a/src/pages/auth/CompanyMemberSignup/CompanyMemberSignup.tsx
+++ b/src/pages/auth/CompanyMemberSignup/CompanyMemberSignup.tsx
@@ -1,0 +1,309 @@
+import React, { useState, useEffect } from 'react';
+import { useForm, FormProvider, useWatch } from 'react-hook-form';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Chip } from '@mui/material';
+import { FloowLogo } from '../../../components/UI/FloowLogo';
+import { Button } from '../../../components/UI/Button';
+import { Input } from '../../../components/UI/Forms/Input';
+import { PasswordInput } from '../../../components/UI/Forms/PasswordInput';
+import { PasswordStrength } from '../../../components/UI/PasswordStrength';
+import { Snackbar } from '../../../components/UI/Snackbar';
+import { authService } from '../../../services/api/auth';
+import { companyMemberService } from '../../../services/api/companyMember';
+import type { CompanyRole } from '../../../services/api/companyMember';
+import { useSchema } from '../../../utils/validation';
+import { extractErrorMessage } from '../../../utils/errorHandler';
+import { CompanyMemberSignupSchema } from './CompanyMemberSignupSchema';
+import type { CompanyMemberSignupFormData } from './CompanyMemberSignupSchema';
+import {
+  SignupContainer,
+  LeftSection,
+  FormContainer,
+  HeaderSection,
+  Title,
+  Subtitle,
+  FormWrapper,
+  DividerContainer,
+  DividerLine,
+  DividerText,
+  SignInLink,
+  ErrorContainer,
+  ErrorTitle,
+  ErrorMessage,
+} from '../WorkerSignup/WorkerSignup.styles';
+
+const ROLE_LABELS: Record<CompanyRole, string> = {
+  COMPANY_ADMIN: 'Admin',
+  MANAGER: 'Manager',
+  EDITOR: 'Editor',
+  VIEWER: 'Viewer',
+};
+
+export const CompanyMemberSignup: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  const { fieldRules, defaultValues, placeHolders, fieldLabels } = useSchema(CompanyMemberSignupSchema);
+
+  const methods = useForm<CompanyMemberSignupFormData>({
+    resolver: yupResolver(fieldRules),
+    defaultValues: { ...defaultValues, email: '' },
+    mode: 'onChange',
+  });
+
+  const { handleSubmit, formState: { errors }, trigger, setValue, control } = methods;
+  const password = useWatch({ control, name: 'password', defaultValue: '' });
+
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCheckingInvitation, setIsCheckingInvitation] = useState(true);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [companyName, setCompanyName] = useState('');
+  const [companyRole, setCompanyRole] = useState<CompanyRole | null>(null);
+  const [invitationEmail, setInvitationEmail] = useState('');
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    variant: 'success' | 'error' | 'warning' | 'info';
+  }>({ open: false, message: '', variant: 'success' });
+
+  useEffect(() => {
+    const checkInvitation = async () => {
+      if (!token) {
+        setTokenError('Invalid invitation link. Missing token parameter.');
+        setIsCheckingInvitation(false);
+        return;
+      }
+
+      try {
+        const { data } = await companyMemberService.checkInvitation(token);
+
+        if (!data.valid) {
+          const msg =
+            data.status === 'EXPIRED'
+              ? 'This invitation has expired. Contact your company administrator for a new one.'
+              : data.status === 'ACCEPTED'
+                ? 'This invitation has already been used.'
+                : 'This invitation is not valid.';
+          setTokenError(msg);
+          setIsCheckingInvitation(false);
+          return;
+        }
+
+        if (data.email) {
+          setInvitationEmail(data.email);
+          setValue('email', data.email);
+        }
+        if (data.companyName) setCompanyName(data.companyName);
+        if (data.companyRole) setCompanyRole(data.companyRole as CompanyRole);
+
+        setIsCheckingInvitation(false);
+      } catch (error) {
+        setTokenError(
+          extractErrorMessage(error, 'Failed to validate invitation. Please try again or contact your administrator.')
+        );
+        setIsCheckingInvitation(false);
+      }
+    };
+
+    checkInvitation();
+  }, [token, setValue]);
+
+  const onSubmit = async (data: CompanyMemberSignupFormData) => {
+    if (!token) {
+      setSnackbar({ open: true, message: 'Invalid invitation token', variant: 'error' });
+      return;
+    }
+
+    setIsLoading(true);
+    setSnackbar({ open: false, message: '', variant: 'success' });
+
+    try {
+      await authService.signupCompanyMember({
+        invitationToken: token,
+        email: data.email,
+        name: data.name,
+        username: data.username,
+        password: data.password,
+      });
+
+      setSnackbar({
+        open: true,
+        message: `Account created successfully! Welcome to ${companyName || 'your company'}. Redirecting to login...`,
+        variant: 'success',
+      });
+
+      setTimeout(() => navigate('/login'), 3000);
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: extractErrorMessage(error, 'Failed to create account. Please try again.'),
+        variant: 'error',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isCheckingInvitation) {
+    return (
+      <SignupContainer>
+        <LeftSection>
+          <FormContainer>
+            <HeaderSection>
+              <FloowLogo variant="light" showText={true} />
+            </HeaderSection>
+            <ErrorContainer>
+              <ErrorTitle>Validating Invitation...</ErrorTitle>
+              <ErrorMessage>Please wait while we verify your invitation link.</ErrorMessage>
+            </ErrorContainer>
+          </FormContainer>
+        </LeftSection>
+      </SignupContainer>
+    );
+  }
+
+  if (tokenError || !token) {
+    return (
+      <SignupContainer>
+        <LeftSection>
+          <FormContainer>
+            <HeaderSection>
+              <FloowLogo variant="light" showText={true} />
+            </HeaderSection>
+            <ErrorContainer>
+              <ErrorTitle>Invalid Invitation Link</ErrorTitle>
+              <ErrorMessage>
+                {tokenError || 'This invitation link is invalid or has expired. Contact your administrator.'}
+              </ErrorMessage>
+              <Button variant="contained" color="primary" onClick={() => navigate('/login')} sx={{ marginTop: '20px' }}>
+                Go to Login
+              </Button>
+            </ErrorContainer>
+          </FormContainer>
+        </LeftSection>
+      </SignupContainer>
+    );
+  }
+
+  const roleLabel = companyRole ? ROLE_LABELS[companyRole] : null;
+
+  return (
+    <FormProvider {...methods}>
+      <SignupContainer>
+        <LeftSection>
+          <FormContainer>
+            <HeaderSection>
+              <FloowLogo variant="light" showText={true} />
+              <Title>
+                {companyName ? `Join ${companyName}` : 'Join Your Team'}
+              </Title>
+              <Subtitle>
+                {roleLabel
+                  ? `You're invited as ${roleLabel}. Complete your profile to get started.`
+                  : 'Complete your profile to join your company workspace.'}
+              </Subtitle>
+              {roleLabel && (
+                <Chip
+                  label={roleLabel}
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{ alignSelf: 'center', mt: 0.5 }}
+                />
+              )}
+            </HeaderSection>
+
+            <FormWrapper onSubmit={handleSubmit(onSubmit)}>
+              <Input
+                name="email"
+                label={fieldLabels.email}
+                type="email"
+                placeholder={placeHolders.email}
+                fullWidth
+                required
+                error={errors.email}
+                isDisabled={true}
+                readOnly={true}
+                defaultValue={invitationEmail}
+                styles={{
+                  input: {
+                    '& input': {
+                      color: '#1e293b !important',
+                      WebkitTextFillColor: '#1e293b !important',
+                      fontWeight: 500,
+                    },
+                  },
+                }}
+              />
+
+              <Input
+                name="name"
+                label={fieldLabels.name}
+                type="text"
+                placeholder={placeHolders.name}
+                fullWidth
+                required
+                error={errors.name}
+              />
+
+              <Input
+                name="username"
+                label={fieldLabels.username}
+                type="text"
+                placeholder={placeHolders.username}
+                fullWidth
+                required
+                error={errors.username}
+              />
+
+              <div>
+                <PasswordInput
+                  name="password"
+                  label={fieldLabels.password}
+                  placeholder={placeHolders.password}
+                  fullWidth
+                  required
+                  error={errors.password}
+                  onChange={() => trigger('confirmPassword')}
+                />
+                <PasswordStrength password={password} />
+              </div>
+
+              <PasswordInput
+                name="confirmPassword"
+                label={fieldLabels.confirmPassword}
+                placeholder={placeHolders.confirmPassword}
+                fullWidth
+                required
+                error={errors.confirmPassword}
+              />
+
+              <Button type="submit" variant="contained" color="primary" size="large" fullWidth disabled={isLoading}>
+                {isLoading ? 'Creating account...' : 'Create Account'}
+              </Button>
+
+              <DividerContainer>
+                <DividerLine />
+                <DividerText>Or</DividerText>
+                <DividerLine />
+              </DividerContainer>
+
+              <SignInLink>
+                Already have an account? <a href="/login">Sign in</a>
+              </SignInLink>
+            </FormWrapper>
+          </FormContainer>
+        </LeftSection>
+
+        <Snackbar
+          open={snackbar.open}
+          message={snackbar.message}
+          variant={snackbar.variant}
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+        />
+      </SignupContainer>
+    </FormProvider>
+  );
+};

--- a/src/pages/auth/CompanyMemberSignup/CompanyMemberSignupSchema.ts
+++ b/src/pages/auth/CompanyMemberSignup/CompanyMemberSignupSchema.ts
@@ -1,0 +1,53 @@
+import { InputValidationRules } from '../../../utils/validation';
+import type { IFields } from '../../../utils/validation';
+
+export const CompanyMemberSignupSchema: IFields = {
+  email: {
+    title: 'email',
+    rule: InputValidationRules.EmailRequired,
+    defaultValue: '',
+    placeHolder: 'your@email.com',
+    label: 'Email',
+    isRequired: true,
+  },
+  name: {
+    title: 'name',
+    rule: InputValidationRules.StringRequired,
+    defaultValue: '',
+    placeHolder: 'Enter your full name',
+    label: 'Full Name',
+    isRequired: true,
+  },
+  username: {
+    title: 'username',
+    rule: InputValidationRules.StringRequired,
+    defaultValue: '',
+    placeHolder: 'Choose a username',
+    label: 'Username',
+    isRequired: true,
+  },
+  password: {
+    title: 'password',
+    rule: InputValidationRules.PasswordRequired,
+    defaultValue: '',
+    placeHolder: 'Create a strong password',
+    label: 'Password',
+    isRequired: true,
+  },
+  confirmPassword: {
+    title: 'confirmPassword',
+    rule: InputValidationRules.RetypePasswordMatched,
+    defaultValue: '',
+    placeHolder: 'Confirm your password',
+    label: 'Confirm Password',
+    isRequired: true,
+  },
+};
+
+export interface CompanyMemberSignupFormData {
+  email: string;
+  name: string;
+  username: string;
+  password: string;
+  confirmPassword: string;
+}

--- a/src/pages/auth/CompanyMemberSignup/index.ts
+++ b/src/pages/auth/CompanyMemberSignup/index.ts
@@ -1,0 +1,1 @@
+export { CompanyMemberSignup } from './CompanyMemberSignup';

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -1,6 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Box, Tabs, Tab } from '@mui/material';
+import PaletteOutlinedIcon from '@mui/icons-material/PaletteOutlined';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
 import { ThemeSettings } from './ThemeSettings';
+import { TeamPage } from './TeamPage';
 
 export const SettingsPage: React.FC = () => {
-  return <ThemeSettings />;
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', px: 4, pt: 2 }}>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab icon={<GroupOutlinedIcon fontSize="small" />} iconPosition="start" label="Team" />
+          <Tab icon={<PaletteOutlinedIcon fontSize="small" />} iconPosition="start" label="Appearance" />
+        </Tabs>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'auto' }}>
+        {tab === 0 && <TeamPage />}
+        {tab === 1 && <ThemeSettings />}
+      </Box>
+    </Box>
+  );
 };

--- a/src/pages/settings/TeamPage/TeamPage.columns.tsx
+++ b/src/pages/settings/TeamPage/TeamPage.columns.tsx
@@ -1,0 +1,134 @@
+import type { ITableColumn } from '../../../components/UI/Table/ITable';
+import { StatusBadge } from './TeamPage.styles';
+import type { Theme } from '@mui/material/styles';
+import { MemberInfo, MemberName, MemberEmail } from '../../../components/UI/Table/Table.styles';
+
+export interface MemberTableRow {
+  id: number;
+  memberId: number;
+  userId: number;
+  name: string;
+  email: string;
+  username: string;
+  companyRole: string;
+  joinedAt: string;
+}
+
+export interface InvitationTableRow {
+  id: number;
+  email: string;
+  companyRole: string;
+  status: string;
+  createdAt: string;
+  expiresAt: string;
+  usedAt: string | null;
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  COMPANY_ADMIN: '#ef4444',
+  MANAGER: '#f59e0b',
+  EDITOR: '#3b82f6',
+  VIEWER: '#6b7280',
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  COMPANY_ADMIN: 'Admin',
+  MANAGER: 'Manager',
+  EDITOR: 'Editor',
+  VIEWER: 'Viewer',
+};
+
+export const getStatusColor = (status: string, theme: Theme): string => {
+  switch (status) {
+    case 'PENDING':
+      return theme.palette.colors.invitation_pending;
+    case 'ACCEPTED':
+      return theme.palette.colors.invitation_accepted;
+    case 'EXPIRED':
+      return theme.palette.colors.invitation_expired;
+    default:
+      return theme.palette.colors.invitation_expired;
+  }
+};
+
+export const createMemberColumns = (): ITableColumn<MemberTableRow>[] => [
+  {
+    id: 'joinedAt',
+    label: 'Joined',
+    accessor: 'joinedAt',
+    sortable: true,
+    width: 'auto',
+  },
+  {
+    id: 'name',
+    label: 'Member',
+    accessor: 'name',
+    sortable: true,
+    width: 'auto',
+    render: (row) => (
+      <MemberInfo>
+        <MemberName>{row.name || row.username}</MemberName>
+        <MemberEmail>{row.email}</MemberEmail>
+      </MemberInfo>
+    ),
+  },
+  {
+    id: 'username',
+    label: 'Username',
+    accessor: 'username',
+    sortable: true,
+    width: 'auto',
+  },
+  {
+    id: 'companyRole',
+    label: 'Role',
+    sortable: true,
+    width: 'auto',
+    render: (row) => (
+      <StatusBadge color={ROLE_COLORS[row.companyRole] ?? '#6b7280'}>
+        {ROLE_LABELS[row.companyRole] ?? row.companyRole}
+      </StatusBadge>
+    ),
+  },
+];
+
+export const createInvitationColumns = (theme: Theme): ITableColumn<InvitationTableRow>[] => [
+  {
+    id: 'email',
+    label: 'Email Address',
+    accessor: 'email',
+    sortable: true,
+  },
+  {
+    id: 'companyRole',
+    label: 'Role',
+    sortable: true,
+    render: (row) => (
+      <StatusBadge color={ROLE_COLORS[row.companyRole] ?? '#6b7280'}>
+        {ROLE_LABELS[row.companyRole] ?? row.companyRole}
+      </StatusBadge>
+    ),
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    sortable: true,
+    render: (row) => (
+      <StatusBadge color={getStatusColor(row.status, theme)}>
+        {row.status}
+      </StatusBadge>
+    ),
+  },
+  {
+    id: 'createdAt',
+    label: 'Sent',
+    sortable: true,
+    render: (row) => new Date(row.createdAt).toLocaleDateString(),
+  },
+  {
+    id: 'expiresAt',
+    label: 'Expires',
+    sortable: true,
+    render: (row) => new Date(row.expiresAt).toLocaleDateString(),
+  },
+];

--- a/src/pages/settings/TeamPage/TeamPage.styles.ts
+++ b/src/pages/settings/TeamPage/TeamPage.styles.ts
@@ -1,0 +1,20 @@
+import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
+
+export const TeamContainer = styled(Box)({
+  width: '100%',
+  height: '100%',
+});
+
+export const StatusBadge = styled('span')<{ color: string }>(({ color, theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '4px 12px',
+  borderRadius: '12px',
+  fontSize: '12px',
+  fontWeight: theme.typography.fontWeightSemiBold,
+  backgroundColor: `${color}20`,
+  color: color,
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+}));

--- a/src/pages/settings/TeamPage/TeamPage.tsx
+++ b/src/pages/settings/TeamPage/TeamPage.tsx
@@ -1,0 +1,258 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTheme, Box, Tabs, Tab } from '@mui/material';
+import GroupOutlinedIcon from '@mui/icons-material/GroupOutlined';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import { PageWrapper } from '../../../components/UI/PageWrapper';
+import Table from '../../../components/UI/Table/Table';
+import type { ITableAction } from '../../../components/UI/Table/ITable';
+import { useGlobalModalOuterContext, ModalSizes, ConfirmationModal } from '../../../components/UI/GlobalModal';
+import { InviteMemberForm } from './components/InviteMemberForm';
+import { ChangeMemberRoleForm } from './components/ChangeMemberRoleForm';
+import { companyMemberService } from '../../../services/api/companyMember';
+import type { MemberResponse, MemberInvitationStatusResponse } from '../../../services/api/companyMember';
+import { MemberResponseCompanyRoleEnum } from '../../../../workflow-api';
+import { useCompanyRole } from '../../../contexts/CompanyRoleContext';
+import { useSnackbar } from '../../../contexts/SnackbarContext';
+import { extractErrorMessage } from '../../../utils/errorHandler';
+import { TeamContainer } from './TeamPage.styles';
+import {
+  createMemberColumns,
+  createInvitationColumns,
+  type MemberTableRow,
+  type InvitationTableRow,
+} from './TeamPage.columns';
+
+export const TeamPage: React.FC = () => {
+  const theme = useTheme();
+  const { setGlobalModalOuterProps, resetGlobalModalOuterProps } = useGlobalModalOuterContext();
+  const { showSuccess, showError } = useSnackbar();
+  const { canInviteMembers, canManageRoles, isLoading: isRoleLoading } = useCompanyRole();
+
+  const [members, setMembers] = useState<MemberTableRow[]>([]);
+  const [invitations, setInvitations] = useState<InvitationTableRow[]>([]);
+  const [loadingMembers, setLoadingMembers] = useState(true);
+  const [loadingInvitations, setLoadingInvitations] = useState(false);
+  const [activeTab, setActiveTab] = useState(0);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      setLoadingMembers(true);
+      const response = await companyMemberService.getMembers();
+      const data = Array.isArray(response.data) ? response.data : [];
+      setMembers(
+        data.map((m: MemberResponse) => ({
+          id: m.memberId ?? 0,
+          memberId: m.memberId ?? 0,
+          userId: m.userId ?? 0,
+          name: m.name ?? '',
+          email: m.email ?? '',
+          username: m.username ?? '',
+          companyRole: m.companyRole ?? '',
+          joinedAt: m.joinedAt ? new Date(m.joinedAt).toLocaleDateString() : '',
+        }))
+      );
+    } catch (error) {
+      showError(extractErrorMessage(error, 'Failed to load team members.'));
+    } finally {
+      setLoadingMembers(false);
+    }
+  }, [showError]);
+
+  const fetchInvitations = useCallback(async () => {
+    try {
+      setLoadingInvitations(true);
+      const response = await companyMemberService.getInvitations();
+      const data = Array.isArray(response.data) ? response.data : [];
+      setInvitations(
+        data.map((inv: MemberInvitationStatusResponse) => ({
+          id: inv.id ?? 0,
+          email: inv.email ?? '',
+          companyRole: inv.companyRole ?? '',
+          status: inv.status ?? '',
+          createdAt: inv.createdAt ?? '',
+          expiresAt: inv.expiresAt ?? '',
+          usedAt: inv.usedAt ?? null,
+        }))
+      );
+    } catch (error) {
+      showError(extractErrorMessage(error, 'Failed to load invitations.'));
+    } finally {
+      setLoadingInvitations(false);
+    }
+  }, [showError]);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  useEffect(() => {
+    if (activeTab === 1 && canInviteMembers) {
+      fetchInvitations();
+    }
+  }, [activeTab, canInviteMembers, fetchInvitations]);
+
+  const handleInviteMember = () => {
+    setGlobalModalOuterProps({
+      isOpen: true,
+      size: ModalSizes.SMALL,
+      fieldName: 'inviteMember',
+      children: (
+        <InviteMemberForm
+          onSuccess={() => {
+            resetGlobalModalOuterProps();
+            fetchInvitations();
+          }}
+          onCancel={() => resetGlobalModalOuterProps()}
+        />
+      ),
+    });
+  };
+
+  const handleChangeRole = useCallback(
+    (member: MemberTableRow) => {
+      setGlobalModalOuterProps({
+        isOpen: true,
+        size: ModalSizes.SMALL,
+        fieldName: 'changeMemberRole',
+        children: (
+          <ChangeMemberRoleForm
+            memberName={member.name || member.email}
+            currentRole={member.companyRole}
+            onConfirm={async (newRole) => {
+              try {
+                await companyMemberService.updateMemberRole(member.memberId, newRole);
+                showSuccess(`${member.name || member.email} role updated.`);
+                resetGlobalModalOuterProps();
+                fetchMembers();
+              } catch (error) {
+                showError(extractErrorMessage(error, 'Failed to update role.'));
+                resetGlobalModalOuterProps();
+              }
+            }}
+            onCancel={() => resetGlobalModalOuterProps()}
+          />
+        ),
+      });
+    },
+    [setGlobalModalOuterProps, resetGlobalModalOuterProps, showSuccess, showError, fetchMembers]
+  );
+
+  const handleRemoveMember = useCallback(
+    (member: MemberTableRow) => {
+      setGlobalModalOuterProps({
+        isOpen: true,
+        size: ModalSizes.SMALL,
+        fieldName: 'removeMember',
+        children: (
+          <ConfirmationModal
+            title="Remove Member"
+            message={`Remove ${member.name || member.email} from the team?`}
+            description="This action cannot be undone."
+            variant="danger"
+            confirmButtonText="Remove"
+            cancelButtonText="Cancel"
+            onConfirm={async () => {
+              try {
+                await companyMemberService.removeMember(member.memberId);
+                showSuccess(`${member.name || member.email} removed.`);
+                resetGlobalModalOuterProps();
+                fetchMembers();
+              } catch (error) {
+                showError(extractErrorMessage(error, 'Failed to remove member.'));
+                resetGlobalModalOuterProps();
+              }
+            }}
+            onCancel={() => resetGlobalModalOuterProps()}
+          />
+        ),
+      });
+    },
+    [setGlobalModalOuterProps, resetGlobalModalOuterProps, showSuccess, showError, fetchMembers]
+  );
+
+  const memberActions: ITableAction<MemberTableRow>[] = useMemo(() => {
+    if (!canManageRoles) return [];
+    return [
+      {
+        id: 'changeRole',
+        label: 'Change Role',
+        onClick: handleChangeRole,
+        isDisabled: (row) => row.companyRole === MemberResponseCompanyRoleEnum.CompanyAdmin,
+      },
+      {
+        id: 'remove',
+        label: 'Remove',
+        onClick: handleRemoveMember,
+        color: 'error' as const,
+        isDisabled: (row) => row.companyRole === MemberResponseCompanyRoleEnum.CompanyAdmin,
+      },
+    ];
+  }, [canManageRoles, handleChangeRole, handleRemoveMember]);
+
+  const memberColumns = useMemo(() => createMemberColumns(), []);
+  const invitationColumns = useMemo(() => createInvitationColumns(theme), [theme]);
+
+  const pageActions = useMemo(() => {
+    if (!canInviteMembers || isRoleLoading) return [];
+    return [
+      {
+        label: 'Invite Member',
+        onClick: handleInviteMember,
+        variant: 'contained' as const,
+        color: 'primary' as const,
+      },
+    ];
+  }, [canInviteMembers, isRoleLoading]);
+
+  return (
+    <TeamContainer>
+      <PageWrapper
+        title="Team"
+        description="Manage your team members and pending invitations."
+        actions={pageActions}
+      >
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+          <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+            <Tab
+              icon={<GroupOutlinedIcon fontSize="small" />}
+              iconPosition="start"
+              label="Members"
+            />
+            {canInviteMembers && (
+              <Tab
+                icon={<MailOutlineIcon fontSize="small" />}
+                iconPosition="start"
+                label="Invitations"
+              />
+            )}
+          </Tabs>
+        </Box>
+
+        {activeTab === 0 && (
+          <Table<MemberTableRow>
+            columns={memberColumns}
+            data={members}
+            loading={loadingMembers}
+            showActions={canManageRoles}
+            actions={memberActions}
+            emptyMessage="No team members found."
+            rowsPerPage={10}
+            showPagination={true}
+            enableStickyLeft={true}
+          />
+        )}
+        {activeTab === 1 && (
+          <Table<InvitationTableRow>
+            columns={invitationColumns}
+            data={invitations}
+            loading={loadingInvitations}
+            emptyMessage="No invitations found. Invite your first team member to get started."
+            rowsPerPage={10}
+            showPagination={true}
+            enableStickyLeft={true}
+          />
+        )}
+      </PageWrapper>
+    </TeamContainer>
+  );
+};

--- a/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/ChangeMemberRoleForm.styles.ts
+++ b/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/ChangeMemberRoleForm.styles.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const FormContainer = styled.div`
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const FormWrapper = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+`;

--- a/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/ChangeMemberRoleForm.tsx
+++ b/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/ChangeMemberRoleForm.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react';
+import { Typography } from '@mui/material';
+import { StandaloneDropdown } from '../../../../../components/UI/Forms/Dropdown';
+import type { CompanyRole } from '../../../../../services/api/companyMember';
+import { MemberInviteRequestCompanyRoleEnum } from '../../../../../../workflow-api';
+import { useGlobalModalInnerContext } from '../../../../../components/UI/GlobalModal';
+import { FormContainer } from './ChangeMemberRoleForm.styles';
+
+interface ChangeMemberRoleFormProps {
+  memberName: string;
+  currentRole: string;
+  onConfirm: (newRole: CompanyRole) => void;
+  onCancel?: () => void;
+}
+
+const ROLE_OPTIONS = [
+  { label: 'Manager', value: MemberInviteRequestCompanyRoleEnum.Manager },
+  { label: 'Editor', value: MemberInviteRequestCompanyRoleEnum.Editor },
+  { label: 'Viewer', value: MemberInviteRequestCompanyRoleEnum.Viewer },
+];
+
+export const ChangeMemberRoleForm: React.FC<ChangeMemberRoleFormProps> = ({
+  memberName,
+  currentRole,
+  onConfirm,
+  onCancel,
+}) => {
+  const selectedRoleRef = useRef<CompanyRole>(
+    (currentRole !== MemberInviteRequestCompanyRoleEnum.CompanyAdmin
+      ? currentRole
+      : MemberInviteRequestCompanyRoleEnum.Manager) as CompanyRole
+  );
+
+  const { updateModalTitle, updateGlobalModalInnerConfig, updateOnClose, updateOnConfirm } =
+    useGlobalModalInnerContext();
+
+  useEffect(() => {
+    updateModalTitle('Change Member Role');
+    updateGlobalModalInnerConfig({
+      confirmModalButtonText: 'Save',
+      cancelButtonText: 'Cancel',
+    });
+    updateOnClose(() => onCancel?.());
+    updateOnConfirm(() => onConfirm(selectedRoleRef.current));
+  }, [updateModalTitle, updateGlobalModalInnerConfig, updateOnClose, updateOnConfirm, onCancel, onConfirm]);
+
+  return (
+    <FormContainer>
+      <Typography variant="body2" color="text.secondary">
+        Change role for <strong>{memberName}</strong>
+      </Typography>
+      <StandaloneDropdown
+        name="companyRole"
+        label="New Role"
+        placeHolder="Select role"
+        preFetchedOptions={ROLE_OPTIONS}
+        defaultValue={selectedRoleRef.current}
+        disablePortal
+        onChange={(value) => {
+          selectedRoleRef.current = value as CompanyRole;
+        }}
+      />
+    </FormContainer>
+  );
+};

--- a/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/index.ts
+++ b/src/pages/settings/TeamPage/components/ChangeMemberRoleForm/index.ts
@@ -1,0 +1,1 @@
+export { ChangeMemberRoleForm } from './ChangeMemberRoleForm';

--- a/src/pages/settings/TeamPage/components/InviteMemberForm/InviteMemberForm.styles.ts
+++ b/src/pages/settings/TeamPage/components/InviteMemberForm/InviteMemberForm.styles.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const FormContainer = styled.div`
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const FormWrapper = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+`;

--- a/src/pages/settings/TeamPage/components/InviteMemberForm/InviteMemberForm.tsx
+++ b/src/pages/settings/TeamPage/components/InviteMemberForm/InviteMemberForm.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { Input } from '../../../../../components/UI/Forms/Input';
+import { StandaloneDropdown } from '../../../../../components/UI/Forms/Dropdown';
+import { companyMemberService } from '../../../../../services/api/companyMember';
+import type { CompanyRole } from '../../../../../services/api/companyMember';
+import { MemberInviteRequestCompanyRoleEnum } from '../../../../../../workflow-api';
+import { useSnackbar } from '../../../../../contexts/SnackbarContext';
+import { useGlobalModalInnerContext } from '../../../../../components/UI/GlobalModal';
+import { extractErrorMessage } from '../../../../../utils/errorHandler';
+import { FormContainer, FormWrapper } from './InviteMemberForm.styles';
+
+interface InviteMemberFormProps {
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+interface InviteFormData {
+  email: string;
+}
+
+const inviteSchema = yup.object({
+  email: yup
+    .string()
+    .required('Email is required')
+    .email('Invalid email format')
+    .max(100, 'Email must be at most 100 characters'),
+});
+
+const ROLE_OPTIONS = [
+  { label: 'Manager', value: MemberInviteRequestCompanyRoleEnum.Manager },
+  { label: 'Editor', value: MemberInviteRequestCompanyRoleEnum.Editor },
+  { label: 'Viewer', value: MemberInviteRequestCompanyRoleEnum.Viewer },
+];
+
+export const InviteMemberForm: React.FC<InviteMemberFormProps> = ({ onSuccess, onCancel }) => {
+  const methods = useForm<InviteFormData>({
+    resolver: yupResolver(inviteSchema),
+    defaultValues: { email: '' },
+    mode: 'onChange',
+  });
+
+  const { handleSubmit, formState: { errors } } = methods;
+  const { showSuccess, showError } = useSnackbar();
+  const { updateModalTitle, updateGlobalModalInnerConfig, updateOnClose, updateOnConfirm } =
+    useGlobalModalInnerContext();
+
+  const [companyRole, setCompanyRole] = useState<CompanyRole>(MemberInviteRequestCompanyRoleEnum.Editor);
+  const companyRoleRef = useRef<CompanyRole>(MemberInviteRequestCompanyRoleEnum.Editor);
+
+  useEffect(() => {
+    updateModalTitle('Invite Team Member');
+    updateGlobalModalInnerConfig({
+      confirmModalButtonText: 'Send Invitation',
+      cancelButtonText: 'Cancel',
+    });
+    updateOnClose(() => onCancel?.());
+    updateOnConfirm(() => {
+      handleSubmit(onSubmit)();
+    });
+  }, [updateModalTitle, updateGlobalModalInnerConfig, updateOnClose, updateOnConfirm, onCancel]);
+
+  const onSubmit = async (data: InviteFormData) => {
+    try {
+      const response = await companyMemberService.inviteMember({
+        email: data.email,
+        companyRole: companyRoleRef.current,
+      });
+      showSuccess(
+        `Invitation sent to ${response.data.email}. Expires: ${new Date(response.data.expiresAt ?? '').toLocaleDateString()}`
+      );
+      onSuccess?.();
+    } catch (error) {
+      showError(extractErrorMessage(error, 'Failed to send invitation. Please try again.'));
+    }
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <FormContainer>
+        <FormWrapper>
+          <Input
+            name="email"
+            label="Email Address"
+            type="email"
+            placeholder="member@example.com"
+            fullWidth
+            error={errors.email}
+          />
+          <StandaloneDropdown
+            name="companyRole"
+            label="Role"
+            placeHolder="Select role"
+            preFetchedOptions={ROLE_OPTIONS}
+            defaultValue={companyRole}
+            disablePortal
+            onChange={(value) => {
+              setCompanyRole(value as CompanyRole);
+              companyRoleRef.current = value as CompanyRole;
+            }}
+          />
+        </FormWrapper>
+      </FormContainer>
+    </FormProvider>
+  );
+};

--- a/src/pages/settings/TeamPage/components/InviteMemberForm/index.ts
+++ b/src/pages/settings/TeamPage/components/InviteMemberForm/index.ts
@@ -1,0 +1,1 @@
+export { InviteMemberForm } from './InviteMemberForm';

--- a/src/pages/settings/TeamPage/components/index.ts
+++ b/src/pages/settings/TeamPage/components/index.ts
@@ -1,0 +1,2 @@
+export { InviteMemberForm } from './InviteMemberForm';
+export { ChangeMemberRoleForm } from './ChangeMemberRoleForm';

--- a/src/pages/settings/TeamPage/index.ts
+++ b/src/pages/settings/TeamPage/index.ts
@@ -1,0 +1,1 @@
+export { TeamPage } from './TeamPage';

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../workflow-api';
 import type { UserRole, AuthTokens, User } from '../../types/auth';
 import type { WorkerSignupRequest, WorkerSignupResponse } from './worker';
+import type { MemberSignupRequest, MemberSignupResponse } from './companyMember';
 
 /**
  * Authentication API Service
@@ -193,6 +194,13 @@ export const authService = {
    */
   async signupWorkerViaInvitation(data: WorkerSignupRequest): Promise<ApiResponse<WorkerSignupResponse>> {
     return await apiClient.post<WorkerSignupResponse>('/api/v1/auth/signup/worker', data);
+  },
+
+  /**
+   * Company member signup via invitation token
+   */
+  async signupCompanyMember(data: MemberSignupRequest): Promise<ApiResponse<MemberSignupResponse>> {
+    return await apiClient.post<MemberSignupResponse>('/api/v1/auth/signup/company-member', data);
   },
 };
 

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -48,6 +48,8 @@ class ApiClient {
     '/auth/google',
     '/auth/signup',
     '/auth/signup/worker',
+    '/auth/signup/company-member',
+    '/companies/members/invitations/check',
     '/auth/refresh',
     '/auth/forgot-password',
     '/auth/reset-password',

--- a/src/services/api/companyMember.ts
+++ b/src/services/api/companyMember.ts
@@ -1,0 +1,58 @@
+import { CompanyMembersApi, Configuration } from '../../../workflow-api';
+import type {
+  MemberResponse,
+  MemberInvitationCheckResponse,
+  MemberInvitationStatusResponse,
+  MemberInviteRequest,
+  MemberInviteResponse,
+  MemberSignupRequest,
+  MemberSignupResponse,
+  MemberResponseCompanyRoleEnum,
+} from '../../../workflow-api';
+import { env } from '../../config/env';
+import { axiosInstance } from './axiosConfig';
+
+export type CompanyRole = MemberResponseCompanyRoleEnum;
+
+export type {
+  MemberResponse,
+  MemberInvitationCheckResponse,
+  MemberInvitationStatusResponse,
+  MemberInviteRequest,
+  MemberInviteResponse,
+  MemberSignupRequest,
+  MemberSignupResponse,
+};
+
+export { MemberResponseCompanyRoleEnum as CompanyRoleEnum };
+
+function getCompanyMembersApi(): CompanyMembersApi {
+  const config = new Configuration({ basePath: env.apiBaseUrl });
+  return new CompanyMembersApi(config, env.apiBaseUrl, axiosInstance);
+}
+
+export const companyMemberService = {
+  async checkInvitation(token: string) {
+    return getCompanyMembersApi().companyMemberCheckInvitation(token);
+  },
+
+  async getMembers() {
+    return getCompanyMembersApi().companyMemberListMembers();
+  },
+
+  async inviteMember(data: MemberInviteRequest) {
+    return getCompanyMembersApi().companyMemberInviteMember(data);
+  },
+
+  async getInvitations() {
+    return getCompanyMembersApi().companyMemberListInvitations();
+  },
+
+  async updateMemberRole(id: number, companyRole: CompanyRole) {
+    return getCompanyMembersApi().companyMemberChangeMemberRole(id, { companyRole });
+  },
+
+  async removeMember(id: number) {
+    return getCompanyMembersApi().companyMemberRemoveMember(id);
+  },
+};

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -98,5 +98,18 @@ export type {
   StepVisitLogSummaryResponse,
 } from './visitLog';
 
+export { companyMemberService } from './companyMember';
+export { MemberResponseCompanyRoleEnum as CompanyRoleEnum } from '../../../workflow-api';
+export type {
+  CompanyRole,
+  MemberResponse,
+  MemberInvitationCheckResponse,
+  MemberInvitationStatusResponse,
+  MemberInviteRequest,
+  MemberInviteResponse,
+  MemberSignupRequest,
+  MemberSignupResponse,
+} from './companyMember';
+
 export { UserRole } from '../../types/auth';
 export type { User, AuthTokens } from '../../types/auth';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -51,6 +51,16 @@ export function getRoleFromToken(token: string): string | null {
 }
 
 /**
+ * Extract user ID from JWT token (parsed from 'sub' claim)
+ */
+export function getUserIdFromToken(token: string): number | null {
+  const payload = decodeJWT(token);
+  if (!payload?.sub) return null;
+  const id = parseInt(payload.sub, 10);
+  return isNaN(id) ? null : id;
+}
+
+/**
  * Check if token is expired
  */
 export function isTokenExpired(token: string): boolean {

--- a/workflow-api/api.ts
+++ b/workflow-api/api.ts
@@ -393,7 +393,7 @@ export interface JobCreateRequest {
     'assignedWorkerIds'?: Array<number>;
     'workflowId'?: number;
     'status'?: JobCreateRequestStatusEnum;
-    'fieldValues'?: { [key: string]: string | number | boolean | object; };
+    'fieldValues'?: { [key: string]: any; };
     'assetIds'?: Array<number>;
     'address'?: AddressRequest;
 }
@@ -501,14 +501,12 @@ export interface JobTemplateWithFieldsResponse {
     'fields'?: Array<JobTemplateFieldResponse>;
 }
 export interface JobUpdateRequest {
-    'templateId'?: number;
     'clientId'?: number;
     'customerId'?: number;
-    'assignedWorkerIds'?: Array<number>;
     'workflowId'?: number;
     'status'?: JobUpdateRequestStatusEnum;
     'archived'?: boolean;
-    'fieldValues'?: { [key: string]: string | number | boolean | object; };
+    'fieldValues'?: { [key: string]: any; };
     'assetIds'?: Array<number>;
     'address'?: AddressRequest;
 }
@@ -591,7 +589,7 @@ export interface JobWorkflowStepUpdateRequest {
     'description'?: string;
     'orderIndex'?: number;
     'status'?: JobWorkflowStepUpdateRequestStatusEnum;
-    'assignedWorkerIds'?: Array<number>;
+    'assignedWorkerIds'?: Set<number>;
 }
 
 export const JobWorkflowStepUpdateRequestStatusEnum = {
@@ -689,6 +687,132 @@ export interface LoginRequest {
 export interface LogoutRequest {
     'refreshToken': string;
 }
+export interface MemberInvitationCheckResponse {
+    'valid'?: boolean;
+    'email'?: string;
+    'companyName'?: string;
+    'companyRole'?: MemberInvitationCheckResponseCompanyRoleEnum;
+    'status'?: MemberInvitationCheckResponseStatusEnum;
+    'expiresAt'?: string;
+}
+
+export const MemberInvitationCheckResponseCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberInvitationCheckResponseCompanyRoleEnum = typeof MemberInvitationCheckResponseCompanyRoleEnum[keyof typeof MemberInvitationCheckResponseCompanyRoleEnum];
+export const MemberInvitationCheckResponseStatusEnum = {
+    Pending: 'PENDING',
+    Accepted: 'ACCEPTED',
+    Expired: 'EXPIRED'
+} as const;
+
+export type MemberInvitationCheckResponseStatusEnum = typeof MemberInvitationCheckResponseStatusEnum[keyof typeof MemberInvitationCheckResponseStatusEnum];
+
+export interface MemberInvitationStatusResponse {
+    'id'?: number;
+    'email'?: string;
+    'companyRole'?: MemberInvitationStatusResponseCompanyRoleEnum;
+    'status'?: MemberInvitationStatusResponseStatusEnum;
+    'createdAt'?: string;
+    'expiresAt'?: string;
+    'usedAt'?: string;
+}
+
+export const MemberInvitationStatusResponseCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberInvitationStatusResponseCompanyRoleEnum = typeof MemberInvitationStatusResponseCompanyRoleEnum[keyof typeof MemberInvitationStatusResponseCompanyRoleEnum];
+export const MemberInvitationStatusResponseStatusEnum = {
+    Pending: 'PENDING',
+    Accepted: 'ACCEPTED',
+    Expired: 'EXPIRED'
+} as const;
+
+export type MemberInvitationStatusResponseStatusEnum = typeof MemberInvitationStatusResponseStatusEnum[keyof typeof MemberInvitationStatusResponseStatusEnum];
+
+export interface MemberInviteRequest {
+    'email': string;
+    'companyRole': MemberInviteRequestCompanyRoleEnum;
+}
+
+export const MemberInviteRequestCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberInviteRequestCompanyRoleEnum = typeof MemberInviteRequestCompanyRoleEnum[keyof typeof MemberInviteRequestCompanyRoleEnum];
+
+export interface MemberInviteResponse {
+    'email'?: string;
+    'companyRole'?: MemberInviteResponseCompanyRoleEnum;
+    'message'?: string;
+    'expiresAt'?: string;
+}
+
+export const MemberInviteResponseCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberInviteResponseCompanyRoleEnum = typeof MemberInviteResponseCompanyRoleEnum[keyof typeof MemberInviteResponseCompanyRoleEnum];
+
+export interface MemberResponse {
+    'memberId'?: number;
+    'userId'?: number;
+    'username'?: string;
+    'email'?: string;
+    'name'?: string;
+    'companyRole'?: MemberResponseCompanyRoleEnum;
+    'active'?: boolean;
+    'joinedAt'?: string;
+}
+
+export const MemberResponseCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberResponseCompanyRoleEnum = typeof MemberResponseCompanyRoleEnum[keyof typeof MemberResponseCompanyRoleEnum];
+
+export interface MemberSignupRequest {
+    'invitationToken': string;
+    'email': string;
+    'username': string;
+    'password': string;
+    'name': string;
+}
+export interface MemberSignupResponse {
+    'memberId'?: number;
+    'username'?: string;
+    'email'?: string;
+    'companyName'?: string;
+    'companyRole'?: MemberSignupResponseCompanyRoleEnum;
+    'message'?: string;
+}
+
+export const MemberSignupResponseCompanyRoleEnum = {
+    CompanyAdmin: 'COMPANY_ADMIN',
+    Manager: 'MANAGER',
+    Editor: 'EDITOR',
+    Viewer: 'VIEWER'
+} as const;
+
+export type MemberSignupResponseCompanyRoleEnum = typeof MemberSignupResponseCompanyRoleEnum[keyof typeof MemberSignupResponseCompanyRoleEnum];
+
 export interface PageMetadata {
     'size'?: number;
     'number'?: number;
@@ -2255,6 +2379,45 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
+         * @param {MemberSignupRequest} memberSignupRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authSignupCompanyMember: async (memberSignupRequest: MemberSignupRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'memberSignupRequest' is not null or undefined
+            assertParamExists('authSignupCompanyMember', 'memberSignupRequest', memberSignupRequest)
+            const localVarPath = `/api/v1/auth/signup/company-member`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(memberSignupRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {WorkerSignupRequest} workerSignupRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2449,6 +2612,18 @@ export const AuthenticationApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {MemberSignupRequest} memberSignupRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async authSignupCompanyMember(memberSignupRequest: MemberSignupRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MemberSignupResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.authSignupCompanyMember(memberSignupRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.authSignupCompanyMember']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {WorkerSignupRequest} workerSignupRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2562,6 +2737,15 @@ export const AuthenticationApiFactory = function (configuration?: Configuration,
         },
         /**
          * 
+         * @param {MemberSignupRequest} memberSignupRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authSignupCompanyMember(memberSignupRequest: MemberSignupRequest, options?: RawAxiosRequestConfig): AxiosPromise<MemberSignupResponse> {
+            return localVarFp.authSignupCompanyMember(memberSignupRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {WorkerSignupRequest} workerSignupRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2672,6 +2856,16 @@ export class AuthenticationApi extends BaseAPI {
      */
     public authSignup(signupRequest: SignupRequest, options?: RawAxiosRequestConfig) {
         return AuthenticationApiFp(this.configuration).authSignup(signupRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {MemberSignupRequest} memberSignupRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public authSignupCompanyMember(memberSignupRequest: MemberSignupRequest, options?: RawAxiosRequestConfig) {
+        return AuthenticationApiFp(this.configuration).authSignupCompanyMember(memberSignupRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3294,6 +3488,447 @@ export class CompanyApi extends BaseAPI {
      */
     public companyUpdateProfile(companyProfileUpdateRequest: CompanyProfileUpdateRequest, options?: RawAxiosRequestConfig) {
         return CompanyApiFp(this.configuration).companyUpdateProfile(companyProfileUpdateRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * CompanyMembersApi - axios parameter creator
+ */
+export const CompanyMembersApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @param {number} id 
+         * @param {{ [key: string]: string; }} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberChangeMemberRole: async (id: number, requestBody: { [key: string]: string; }, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('companyMemberChangeMemberRole', 'id', id)
+            // verify required parameter 'requestBody' is not null or undefined
+            assertParamExists('companyMemberChangeMemberRole', 'requestBody', requestBody)
+            const localVarPath = `/api/v1/companies/members/{id}/role`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {string} token 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberCheckInvitation: async (token: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'token' is not null or undefined
+            assertParamExists('companyMemberCheckInvitation', 'token', token)
+            const localVarPath = `/api/v1/companies/members/invitations/check`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (token !== undefined) {
+                localVarQueryParameter['token'] = token;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {MemberInviteRequest} memberInviteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberInviteMember: async (memberInviteRequest: MemberInviteRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'memberInviteRequest' is not null or undefined
+            assertParamExists('companyMemberInviteMember', 'memberInviteRequest', memberInviteRequest)
+            const localVarPath = `/api/v1/companies/members/invite`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(memberInviteRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberListInvitations: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/companies/members/invitations`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberListMembers: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/companies/members`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberRemoveMember: async (id: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('companyMemberRemoveMember', 'id', id)
+            const localVarPath = `/api/v1/companies/members/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * CompanyMembersApi - functional programming interface
+ */
+export const CompanyMembersApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = CompanyMembersApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @param {number} id 
+         * @param {{ [key: string]: string; }} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberChangeMemberRole(id: number, requestBody: { [key: string]: string; }, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MemberResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberChangeMemberRole(id, requestBody, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberChangeMemberRole']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {string} token 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberCheckInvitation(token: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MemberInvitationCheckResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberCheckInvitation(token, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberCheckInvitation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {MemberInviteRequest} memberInviteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberInviteMember(memberInviteRequest: MemberInviteRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MemberInviteResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberInviteMember(memberInviteRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberInviteMember']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberListInvitations(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemberInvitationStatusResponse>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberListInvitations(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberListInvitations']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberListMembers(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemberResponse>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberListMembers(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberListMembers']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async companyMemberRemoveMember(id: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.companyMemberRemoveMember(id, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CompanyMembersApi.companyMemberRemoveMember']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * CompanyMembersApi - factory interface
+ */
+export const CompanyMembersApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = CompanyMembersApiFp(configuration)
+    return {
+        /**
+         * 
+         * @param {number} id 
+         * @param {{ [key: string]: string; }} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberChangeMemberRole(id: number, requestBody: { [key: string]: string; }, options?: RawAxiosRequestConfig): AxiosPromise<MemberResponse> {
+            return localVarFp.companyMemberChangeMemberRole(id, requestBody, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {string} token 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberCheckInvitation(token: string, options?: RawAxiosRequestConfig): AxiosPromise<MemberInvitationCheckResponse> {
+            return localVarFp.companyMemberCheckInvitation(token, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {MemberInviteRequest} memberInviteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberInviteMember(memberInviteRequest: MemberInviteRequest, options?: RawAxiosRequestConfig): AxiosPromise<MemberInviteResponse> {
+            return localVarFp.companyMemberInviteMember(memberInviteRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberListInvitations(options?: RawAxiosRequestConfig): AxiosPromise<Array<MemberInvitationStatusResponse>> {
+            return localVarFp.companyMemberListInvitations(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberListMembers(options?: RawAxiosRequestConfig): AxiosPromise<Array<MemberResponse>> {
+            return localVarFp.companyMemberListMembers(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {number} id 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        companyMemberRemoveMember(id: number, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.companyMemberRemoveMember(id, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * CompanyMembersApi - object-oriented interface
+ */
+export class CompanyMembersApi extends BaseAPI {
+    /**
+     * 
+     * @param {number} id 
+     * @param {{ [key: string]: string; }} requestBody 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberChangeMemberRole(id: number, requestBody: { [key: string]: string; }, options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberChangeMemberRole(id, requestBody, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {string} token 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberCheckInvitation(token: string, options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberCheckInvitation(token, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {MemberInviteRequest} memberInviteRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberInviteMember(memberInviteRequest: MemberInviteRequest, options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberInviteMember(memberInviteRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberListInvitations(options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberListInvitations(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberListMembers(options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberListMembers(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} id 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public companyMemberRemoveMember(id: number, options?: RawAxiosRequestConfig) {
+        return CompanyMembersApiFp(this.configuration).companyMemberRemoveMember(id, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -5472,6 +6107,49 @@ export const JobWorkflowsApiAxiosParamCreator = function (configuration?: Config
         },
         /**
          * 
+         * @param {number} jobWorkflowId 
+         * @param {Array<number>} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        jobWorkflowAssignWorkersToAllSteps: async (jobWorkflowId: number, requestBody: Array<number>, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'jobWorkflowId' is not null or undefined
+            assertParamExists('jobWorkflowAssignWorkersToAllSteps', 'jobWorkflowId', jobWorkflowId)
+            // verify required parameter 'requestBody' is not null or undefined
+            assertParamExists('jobWorkflowAssignWorkersToAllSteps', 'requestBody', requestBody)
+            const localVarPath = `/api/v1/job-workflows/{jobWorkflowId}/assign-workers`
+                .replace(`{${"jobWorkflowId"}}`, encodeURIComponent(String(jobWorkflowId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {number} jobId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5782,6 +6460,19 @@ export const JobWorkflowsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {number} jobWorkflowId 
+         * @param {Array<number>} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async jobWorkflowAssignWorkersToAllSteps(jobWorkflowId: number, requestBody: Array<number>, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JobWorkflowResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.jobWorkflowAssignWorkersToAllSteps(jobWorkflowId, requestBody, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['JobWorkflowsApi.jobWorkflowAssignWorkersToAllSteps']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {number} jobId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5898,6 +6589,16 @@ export const JobWorkflowsApiFactory = function (configuration?: Configuration, b
         },
         /**
          * 
+         * @param {number} jobWorkflowId 
+         * @param {Array<number>} requestBody 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        jobWorkflowAssignWorkersToAllSteps(jobWorkflowId: number, requestBody: Array<number>, options?: RawAxiosRequestConfig): AxiosPromise<JobWorkflowResponse> {
+            return localVarFp.jobWorkflowAssignWorkersToAllSteps(jobWorkflowId, requestBody, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {number} jobId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5989,6 +6690,17 @@ export class JobWorkflowsApi extends BaseAPI {
      */
     public jobWorkflowAssignWorkerToAllSteps(jobWorkflowId: number, workerId: number, options?: RawAxiosRequestConfig) {
         return JobWorkflowsApiFp(this.configuration).jobWorkflowAssignWorkerToAllSteps(jobWorkflowId, workerId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {number} jobWorkflowId 
+     * @param {Array<number>} requestBody 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public jobWorkflowAssignWorkersToAllSteps(jobWorkflowId: number, requestBody: Array<number>, options?: RawAxiosRequestConfig) {
+        return JobWorkflowsApiFp(this.configuration).jobWorkflowAssignWorkersToAllSteps(jobWorkflowId, requestBody, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
- Add /signup/company-member page with token validation and role badge
- Add CompanyRoleContext with permission flags derived from membership
- Add companyMemberService wrapping generated CompanyMembersApi
- Add Settings → Team page with Members/Invitations tabs, invite modal, role change and remove actions
- Add signupCompanyMember to authService
- Add getUserIdFromToken and username-based member matching in CompanyRoleContext
- Wire CompanyRoleProvider in App.tsx