### PR TITLE
refactor(global-modal): split ConfirmationModal into layered structure

### DIFF
--- a/src/components/UI/GlobalModal/Utils/GlobalConst.ts
+++ b/src/components/UI/GlobalModal/Utils/GlobalConst.ts
@@ -1,0 +1,6 @@
+export const CONFIRMATION_MODAL_DEFAULTS = {
+  title: 'Confirm Action',
+  confirmButtonText: 'Confirm',
+  cancelButtonText: 'Cancel',
+  variant: 'default' as const,
+};

--- a/src/components/UI/GlobalModal/screens/ConfirmationModal.style.ts
+++ b/src/components/UI/GlobalModal/screens/ConfirmationModal.style.ts
@@ -4,14 +4,14 @@ import { floowColors } from '../../../../theme/colors';
 import type { ConfirmationModalProps } from './IConfirmationModal';
 
 export const ModalContainer = styled(Box)({
-  padding: '16px',
+  padding: '1rem',
 });
 
 export const MessageText = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'colorVariant' && prop !== 'hasDescription',
 })<{ colorVariant?: ConfirmationModalProps['variant']; hasDescription?: boolean }>(
   ({ colorVariant, hasDescription }) => ({
-    marginBottom: hasDescription ? '16px' : 0,
+    marginBottom: hasDescription ? '1rem' : 0,
     color:
       colorVariant === 'warning'
         ? floowColors.warning.main
@@ -21,6 +21,7 @@ export const MessageText = styled(Typography, {
     fontWeight: colorVariant === 'danger' || colorVariant === 'warning' ? 500 : 400,
   })
 );
+
 export const DescriptionText = styled(Typography)({
   color: floowColors.text.secondary,
 });

--- a/src/components/UI/GlobalModal/screens/ConfirmationModal.style.ts
+++ b/src/components/UI/GlobalModal/screens/ConfirmationModal.style.ts
@@ -1,0 +1,26 @@
+import { Box, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { floowColors } from '../../../../theme/colors';
+import type { ConfirmationModalProps } from './IConfirmationModal';
+
+export const ModalContainer = styled(Box)({
+  padding: '16px',
+});
+
+export const MessageText = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'colorVariant' && prop !== 'hasDescription',
+})<{ colorVariant?: ConfirmationModalProps['variant']; hasDescription?: boolean }>(
+  ({ colorVariant, hasDescription }) => ({
+    marginBottom: hasDescription ? '16px' : 0,
+    color:
+      colorVariant === 'warning'
+        ? floowColors.warning.main
+        : colorVariant === 'danger'
+          ? floowColors.error.main
+          : floowColors.text.primary,
+    fontWeight: colorVariant === 'danger' || colorVariant === 'warning' ? 500 : 400,
+  })
+);
+export const DescriptionText = styled(Typography)({
+  color: floowColors.text.secondary,
+});

--- a/src/components/UI/GlobalModal/screens/ConfirmationModal.tsx
+++ b/src/components/UI/GlobalModal/screens/ConfirmationModal.tsx
@@ -1,83 +1,31 @@
 import { useEffect } from 'react';
 import { useGlobalModalInnerContext } from '../context';
-import { Box, Typography } from '@mui/material';
-import { floowColors } from '../../../../theme/colors';
-
-export interface ConfirmationModalProps {
-  /**
-   * The title of the confirmation modal
-   */
-  title?: string;
-
-  /**
-   * The message to display in the confirmation modal
-   */
-  message: string;
-
-  /**
-   * The text for the confirm button
-   * @default 'Confirm'
-   */
-  confirmButtonText?: string;
-
-  /**
-   * The text for the cancel button
-   * @default 'Cancel'
-   */
-  cancelButtonText?: string;
-
-  /**
-   * Callback when the user confirms
-   */
-  onConfirm: () => void;
-
-  /**
-   * Callback when the user cancels
-   */
-  onCancel?: () => void;
-
-  /**
-   * Additional description or details
-   */
-  description?: string;
-
-  /**
-   * Variant of the confirmation modal (affects styling/severity)
-   * @default 'default'
-   */
-  variant?: 'default' | 'warning' | 'danger';
-}
+import { ModalContainer, MessageText, DescriptionText } from './ConfirmationModal.style';
+import type { ConfirmationModalProps } from './IConfirmationModal';
+import { CONFIRMATION_MODAL_DEFAULTS } from '../Utils/GlobalConst';
 
 export const ConfirmationModal = ({
-  title = 'Confirm Action',
+  title = CONFIRMATION_MODAL_DEFAULTS.title,
   message,
-  confirmButtonText = 'Confirm',
-  cancelButtonText = 'Cancel',
+  confirmButtonText = CONFIRMATION_MODAL_DEFAULTS.confirmButtonText,
+  cancelButtonText = CONFIRMATION_MODAL_DEFAULTS.cancelButtonText,
   onConfirm,
   onCancel,
   description,
-  variant = 'default',
+  variant = CONFIRMATION_MODAL_DEFAULTS.variant,
 }: ConfirmationModalProps) => {
-  const {
-    updateModalTitle,
-    updateGlobalModalInnerConfig,
-    updateOnClose,
-    updateOnConfirm,
-  } = useGlobalModalInnerContext();
+  const { updateModalTitle, updateGlobalModalInnerConfig, updateOnClose, updateOnConfirm } =
+    useGlobalModalInnerContext();
 
   useEffect(() => {
-    // Configure modal
     updateModalTitle(title);
-
     updateGlobalModalInnerConfig({
       confirmModalButtonText: confirmButtonText,
       cancelButtonText: cancelButtonText,
     });
-
     updateOnClose(() => {
       onCancel?.();
     });
-
     updateOnConfirm(() => {
       onConfirm();
     });
@@ -93,34 +41,12 @@ export const ConfirmationModal = ({
     updateOnConfirm,
   ]);
 
-  const getMessageColor = () => {
-    switch (variant) {
-      case 'warning':
-        return floowColors.warning.main;
-      case 'danger':
-        return floowColors.error.main;
-      default:
-        return floowColors.text.primary;
-    }
-  };
-
   return (
-    <Box sx={{ p: 2 }}>
-      <Typography
-        variant="body1"
-        sx={{
-          mb: description ? 2 : 0,
-          color: getMessageColor(),
-          fontWeight: variant === 'danger' || variant === 'warning' ? 500 : 400,
-        }}
-      >
+    <ModalContainer>
+      <MessageText variant="body1" colorVariant={variant} hasDescription={!!description}>
         {message}
-      </Typography>
-      {description && (
-        <Typography variant="body2" sx={{ color: floowColors.text.secondary }}>
-          {description}
-        </Typography>
-      )}
-    </Box>
+      </MessageText>
+      {description && <DescriptionText variant="body2">{description}</DescriptionText>}
+    </ModalContainer>
   );
 };

--- a/src/components/UI/GlobalModal/screens/IConfirmationModal.ts
+++ b/src/components/UI/GlobalModal/screens/IConfirmationModal.ts
@@ -1,0 +1,10 @@
+export interface ConfirmationModalProps {
+  title?: string;
+  message: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  description?: string;
+  variant?: 'default' | 'warning' | 'danger';
+}


### PR DESCRIPTION
Extract interface, styled components, and constants into separate files. Fix colorVariant prop collision with MUI Typography variant.

No functional changes.