### PR TITLE
feat(sla-timer): redesign SLA timer fields with days+hours duration inputs

### DIFF
--- a/src/pages/company/components/JobEventsSection.tsx
+++ b/src/pages/company/components/JobEventsSection.tsx
@@ -5,11 +5,11 @@ import AddIcon from '@mui/icons-material/Add';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
-import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+//import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 // import PendingActionsIcon from '@mui/icons-material/PendingActions';
 // import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { useNavigate } from 'react-router-dom';
-import { useCurrency } from '../../../contexts/CurrencyContext';
+//import { useCurrency } from '../../../contexts/CurrencyContext';
 import { Button } from '../../../components/UI/Button';
 import { useGlobalModalOuterContext, ModalSizes, ConfirmationModal } from '../../../components/UI/GlobalModal';
 import { AddJobWizard } from '../../jobs/components/AddJobWizard';
@@ -131,14 +131,14 @@ const statCardSx = {
 
 function StatBoxesRow({
   jobs,
-  estimateSentTotal,
+  // estimateSentTotal,
   //awaitingInvoiceTotal,
 }: {
   jobs: JobResponse[];
   estimateSentTotal: number;
   awaitingInvoiceTotal: number;
 }) {
-  const { formatCurrency } = useCurrency();
+  //const { formatCurrency } = useCurrency();
   const inProgress = jobs.filter((j) => j.status === 'IN_PROGRESS').length;
   const total = jobs.length;
   const progressPct = total > 0 ? Math.round((inProgress / total) * 100) : 0;

--- a/src/pages/workflows/components/StepForm/StepForm.styles.ts
+++ b/src/pages/workflows/components/StepForm/StepForm.styles.ts
@@ -1,4 +1,5 @@
 import { Box, Divider, Typography, styled } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { rem, Bold } from '../../../../components/UI/Typography/utility';
 
 export const SectionDivider = styled(Divider)(({ theme }) => ({
@@ -31,22 +32,85 @@ export const SectionLabel = styled(Typography)(({ theme }) => ({
 
 export const TimerFieldsContainer = styled(Box)(({ theme }) => ({
   marginTop: theme.spacing(1),
-  paddingLeft: theme.spacing(1),
-  borderLeft: `2px solid ${theme.palette.colors.grey_200}`,
+  padding: theme.spacing(2),
+  backgroundColor: alpha(theme.palette.primary.main, 0.03),
+  border: `1px solid ${theme.palette.colors?.grey_200 ?? theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(1.5),
 }));
 
-export const FieldHint = styled(Typography)<{ hintVariant?: 'warning' | 'error' }>(
+export const TimerGrid = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: theme.spacing(2),
+}));
+
+export const TimerFieldBlock = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(6),
+}));
+
+export const TimerFieldLabel = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.5),
+  fontSize: rem(13),
+  fontWeight: Bold._700,
+  color: theme.palette.colors?.grey_600 ?? theme.palette.text.secondary,
+  lineHeight: rem(20),
+}));
+
+export const TimerFieldLabelIcon = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  '& svg': {
+    fontSize: rem(15),
+    color: theme.palette.text.secondary,
+  },
+}));
+
+export const FieldHint = styled(Box)<{ hintVariant?: 'warning' | 'error' }>(
   ({ theme, hintVariant }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.4),
     fontSize: rem(11),
-    marginTop: theme.spacing(0.25),
+    fontWeight: Bold._500,
+    paddingBlock: rem(3),
+    paddingInline: rem(7),
+    borderRadius: rem(4),
+    width: 'fit-content',
+    backgroundColor:
+      hintVariant === 'error'
+        ? alpha(theme.palette.error.main, 0.09)
+        : hintVariant === 'warning'
+          ? alpha(theme.palette.warning.main, 0.10)
+          : alpha(theme.palette.text.secondary, 0.07),
     color:
       hintVariant === 'error'
         ? theme.palette.error.main
         : hintVariant === 'warning'
-          ? theme.palette.warning.main
+          ? (theme.palette.warning as any).dark ?? theme.palette.warning.main
           : theme.palette.text.secondary,
+    '& svg': {
+      fontSize: rem(12),
+    },
   })
 );
+
+export const DurationInputRow = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: theme.spacing(1),
+}));
+
+export const DurationUnit = styled(Typography)(({ theme }) => ({
+  fontSize: rem(12),
+  color: theme.palette.text.secondary,
+  fontWeight: Bold._500,
+  userSelect: 'none',
+  lineHeight: 1,
+}));

--- a/src/pages/workflows/components/StepForm/StepForm.tsx
+++ b/src/pages/workflows/components/StepForm/StepForm.tsx
@@ -4,7 +4,26 @@ import { SetupFormWrapper } from '../../../../components/UI/SetupFormWrapper';
 import { StepFormFields } from './StepFormFields';
 import { useGlobalModalInnerContext } from '../../../../components/UI/GlobalModal/context';
 
-const MINUTES_PER_DAY = 24 * 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const MINUTES_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR;
+
+const toFormDuration = (minutes?: number) => {
+  if (!minutes) return { days: undefined, hours: undefined };
+  const days = Math.floor(minutes / MINUTES_PER_DAY);
+  const hours = Math.floor((minutes % MINUTES_PER_DAY) / MINUTES_PER_HOUR);
+  return {
+    days: days > 0 ? days : undefined,
+    hours: hours > 0 ? hours : undefined,
+  };
+};
+
+const toMinutes = (days?: number, hours?: number): number | undefined => {
+  const d = days ?? 0;
+  const h = hours ?? 0;
+  if (!d && !h) return undefined;
+  return (d * HOURS_PER_DAY + h) * MINUTES_PER_HOUR;
+};
 
 export interface StepFormStep {
   id: number;
@@ -46,17 +65,18 @@ export const StepForm: React.FC<StepFormProps> = ({
   useEffect(() => {
     if (initialStep) {
       const hasTimer = !!(initialStep.expectedDurationMinutes || initialStep.maximumDurationMinutes);
+      const expected = toFormDuration(initialStep.expectedDurationMinutes);
+      const maximum = toFormDuration(initialStep.maximumDurationMinutes);
+
       setStepData({
         name: initialStep.name || '',
         description: initialStep.description || '',
         optional: initialStep.optional || false,
         enableTimer: hasTimer,
-        expectedDurationDays: initialStep.expectedDurationMinutes
-          ? initialStep.expectedDurationMinutes / MINUTES_PER_DAY
-          : undefined,
-        maximumDurationDays: initialStep.maximumDurationMinutes
-          ? initialStep.maximumDurationMinutes / MINUTES_PER_DAY
-          : undefined,
+        expectedDurationDays: expected.days,
+        expectedDurationHours: expected.hours,
+        maximumDurationDays: maximum.days,
+        maximumDurationHours: maximum.hours,
       });
     }
   }, [initialStep]);
@@ -68,11 +88,11 @@ export const StepForm: React.FC<StepFormProps> = ({
         name: data.name,
         description: data.description || undefined,
         optional: data.optional || false,
-        expectedDurationMinutes: data.enableTimer && data.expectedDurationDays
-          ? Math.round(data.expectedDurationDays * MINUTES_PER_DAY)
+        expectedDurationMinutes: data.enableTimer
+          ? toMinutes(data.expectedDurationDays, data.expectedDurationHours)
           : undefined,
-        maximumDurationMinutes: data.enableTimer && data.maximumDurationDays
-          ? Math.round(data.maximumDurationDays * MINUTES_PER_DAY)
+        maximumDurationMinutes: data.enableTimer
+          ? toMinutes(data.maximumDurationDays, data.maximumDurationHours)
           : undefined,
       };
 

--- a/src/pages/workflows/components/StepForm/StepFormFields.tsx
+++ b/src/pages/workflows/components/StepForm/StepFormFields.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import TimerIcon from '@mui/icons-material/Timer';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { InputAdornment } from '@mui/material';
 import { StepFormSchema } from '../../schema/StepFormSchema';
 import { useSchema } from '../../../../utils/validation';
 import { Input, TextArea, Checkbox } from '../../../../components/UI/Forms';
@@ -56,31 +61,87 @@ export const StepFormFields: React.FC = () => {
 
       {enableTimer && (
         <S.TimerFieldsContainer>
-          <FormField label={fieldLabels.expectedDurationDays} required={isRequireds.expectedDurationDays}>
-            <Input
-              name={fieldTitles.expectedDurationDays}
-              placeholder={placeHolders.expectedDurationDays}
-              hideErrorMessage={false}
-              type="number"
-              inputProps={{ min: 1, step: 1 }}
-            />
-            <S.FieldHint variant="caption" hintVariant="warning">
-              Step turns orange after this period
-            </S.FieldHint>
-          </FormField>
+          <S.TimerGrid>
+            {/* Expected Duration */}
+            <S.TimerFieldBlock>
+              <S.TimerFieldLabel>
+                <S.TimerFieldLabelIcon>
+                  <AccessTimeIcon />
+                </S.TimerFieldLabelIcon>
+                {fieldLabels.expectedDurationDays}
+              </S.TimerFieldLabel>
+              <S.DurationInputRow>
+                <Input
+                  name={fieldTitles.expectedDurationDays}
+                  placeholder={placeHolders.expectedDurationDays}
+                  hideErrorMessage={false}
+                  type="number"
+                  inputProps={{ min: 0, step: 1 }}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <S.DurationUnit>days</S.DurationUnit>
+                    </InputAdornment>
+                  }
+                />
+                <Input
+                  name={fieldTitles.expectedDurationHours}
+                  placeholder={placeHolders.expectedDurationHours}
+                  hideErrorMessage={false}
+                  type="number"
+                  inputProps={{ min: 0, max: 23, step: 1 }}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <S.DurationUnit>hrs</S.DurationUnit>
+                    </InputAdornment>
+                  }
+                />
+              </S.DurationInputRow>
+              <S.FieldHint hintVariant="warning">
+                <WarningAmberIcon />
+                Step turns orange after this period
+              </S.FieldHint>
+            </S.TimerFieldBlock>
 
-          <FormField label={fieldLabels.maximumDurationDays} required={isRequireds.maximumDurationDays}>
-            <Input
-              name={fieldTitles.maximumDurationDays}
-              placeholder={placeHolders.maximumDurationDays}
-              hideErrorMessage={false}
-              type="number"
-              inputProps={{ min: 1, step: 1 }}
-            />
-            <S.FieldHint variant="caption" hintVariant="error">
-              SLA breach alert after this period
-            </S.FieldHint>
-          </FormField>
+            {/* Maximum Deadline */}
+            <S.TimerFieldBlock>
+              <S.TimerFieldLabel>
+                <S.TimerFieldLabelIcon>
+                  <ScheduleIcon />
+                </S.TimerFieldLabelIcon>
+                {fieldLabels.maximumDurationDays}
+              </S.TimerFieldLabel>
+              <S.DurationInputRow>
+                <Input
+                  name={fieldTitles.maximumDurationDays}
+                  placeholder={placeHolders.maximumDurationDays}
+                  hideErrorMessage={false}
+                  type="number"
+                  inputProps={{ min: 0, step: 1 }}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <S.DurationUnit>days</S.DurationUnit>
+                    </InputAdornment>
+                  }
+                />
+                <Input
+                  name={fieldTitles.maximumDurationHours}
+                  placeholder={placeHolders.maximumDurationHours}
+                  hideErrorMessage={false}
+                  type="number"
+                  inputProps={{ min: 0, max: 23, step: 1 }}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <S.DurationUnit>hrs</S.DurationUnit>
+                    </InputAdornment>
+                  }
+                />
+              </S.DurationInputRow>
+              <S.FieldHint hintVariant="error">
+                <ErrorOutlineIcon />
+                SLA breach alert after this period
+              </S.FieldHint>
+            </S.TimerFieldBlock>
+          </S.TimerGrid>
         </S.TimerFieldsContainer>
       )}
     </>

--- a/src/pages/workflows/schema/StepFormSchema.ts
+++ b/src/pages/workflows/schema/StepFormSchema.ts
@@ -35,16 +35,32 @@ export const StepFormSchema: IFields = {
     title: 'expectedDurationDays',
     rule: InputValidationRules.NumberNotRequired,
     defaultValue: undefined,
-    placeHolder: 'e.g. 4',
-    label: 'Expected Duration (days)',
+    placeHolder: '0',
+    label: 'Expected Duration',
+    isRequired: false,
+  },
+  expectedDurationHours: {
+    title: 'expectedDurationHours',
+    rule: InputValidationRules.NumberNotRequired,
+    defaultValue: undefined,
+    placeHolder: '0',
+    label: 'hrs',
     isRequired: false,
   },
   maximumDurationDays: {
     title: 'maximumDurationDays',
     rule: InputValidationRules.NumberNotRequired,
     defaultValue: undefined,
-    placeHolder: 'e.g. 5',
-    label: 'Maximum Deadline (days)',
+    placeHolder: '0',
+    label: 'Maximum Deadline',
+    isRequired: false,
+  },
+  maximumDurationHours: {
+    title: 'maximumDurationHours',
+    rule: InputValidationRules.NumberNotRequired,
+    defaultValue: undefined,
+    placeHolder: '0',
+    label: 'hrs',
     isRequired: false,
   },
 };
@@ -55,5 +71,7 @@ export interface StepFormData {
   optional?: boolean;
   enableTimer?: boolean;
   expectedDurationDays?: number;
+  expectedDurationHours?: number;
   maximumDurationDays?: number;
+  maximumDurationHours?: number;
 }


### PR DESCRIPTION


Replace single decimal-day inputs with split days/hours pickers so sub-day precision is preserved when converting to/from the backend's minute-based fields (expectedDurationMinutes / maximumDurationMinutes). Layout is now a two-column panel with labeled fields, unit adornments, and coloured hint badges instead of floating hint text.