### PR TITLE
fix(config): use sessionStorage in dev mode so localhost is the defau…

### DIFF
--- a/src/components/AppConfiguration/AppConfiguration.tsx
+++ b/src/components/AppConfiguration/AppConfiguration.tsx
@@ -5,6 +5,8 @@ import { ConfigurationScreen } from './ConfigurationScreen';
 
 const STORAGE_KEY = 'app_environment_config';
 
+const getStorage = (): Storage => (import.meta.env.DEV ? sessionStorage : localStorage);
+
 export interface EnvironmentConfig {
   environment: {
     label: string;
@@ -18,8 +20,8 @@ export const AppConfiguration = () => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleConfirm = useCallback((config: EnvironmentConfig) => {
-    // Get previous configuration
-    const prevConfigStr = localStorage.getItem(STORAGE_KEY);
+    const storage = getStorage();
+    const prevConfigStr = storage.getItem(STORAGE_KEY);
     let prevConfig: EnvironmentConfig | null = null;
 
     if (prevConfigStr) {
@@ -30,8 +32,7 @@ export const AppConfiguration = () => {
       }
     }
 
-    // Save new configuration
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+    storage.setItem(STORAGE_KEY, JSON.stringify(config));
 
     // If environment changed, reload the page
     if (!prevConfig || prevConfig.environment.value !== config.environment.value) {

--- a/src/components/AppConfiguration/ConfigurationModal.tsx
+++ b/src/components/AppConfiguration/ConfigurationModal.tsx
@@ -9,6 +9,8 @@ interface ConfigurationModalProps {
 
 const STORAGE_KEY = 'app_environment_config';
 
+const getStorage = (): Storage => (import.meta.env.DEV ? sessionStorage : localStorage);
+
 const ENVIRONMENT_OPTIONS = [
   { label: 'Local', value: 'http://localhost:5173' },
   { label: 'Dev', value: 'https://api.dev2.workfloow.app' },
@@ -16,7 +18,7 @@ const ENVIRONMENT_OPTIONS = [
 ];
 
 const getStoredConfig = (): EnvironmentConfig => {
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = getStorage().getItem(STORAGE_KEY);
   if (stored) {
     try {
       return JSON.parse(stored);
@@ -24,9 +26,7 @@ const getStoredConfig = (): EnvironmentConfig => {
       console.error('Failed to parse stored config:', e);
     }
   }
-  return {
-    environment: ENVIRONMENT_OPTIONS[0],
-  };
+  return { environment: ENVIRONMENT_OPTIONS[0] };
 };
 
 export const ConfigurationModal = ({ onConfirm, onCancel }: ConfigurationModalProps) => {

--- a/src/components/AppConfiguration/ConfigurationScreen.tsx
+++ b/src/components/AppConfiguration/ConfigurationScreen.tsx
@@ -9,14 +9,12 @@ interface ConfigurationScreenProps {
 
 const STORAGE_KEY = 'app_environment_config';
 
-// Get environment URLs from Vite env variables
-// In development: BASE_URL is local, PRODUCTION_URL is prod
-// In production: BASE_URL is prod, LOCAL_URL is local
+const getStorage = (): Storage => (import.meta.env.DEV ? sessionStorage : localStorage);
+
 const ENVIRONMENT_OPTIONS = [
   {
     label: 'Local',
-    value: import.meta.env.VITE_API_LOCAL_URL ||
-           (import.meta.env.DEV ? import.meta.env.VITE_API_BASE_URL : 'http://localhost:5173')
+    value: import.meta.env.VITE_API_LOCAL_URL || 'http://localhost:5173'
   },
   {
     label: 'Dev',
@@ -29,30 +27,24 @@ const ENVIRONMENT_OPTIONS = [
 ];
 
 const getStoredConfig = (): EnvironmentConfig => {
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const storage = getStorage();
+  const stored = storage.getItem(STORAGE_KEY);
   if (stored) {
     try {
       const config = JSON.parse(stored);
-      // Validate that the stored value matches one of our options
       const matchingEnv = ENVIRONMENT_OPTIONS.find(opt => opt.value === config.environment.value);
       if (matchingEnv) {
-        return {
-          environment: matchingEnv,
-        };
+        return { environment: matchingEnv };
       } else {
-        // Clear invalid stored config
         console.warn('Stored config has invalid URL, clearing:', config.environment.value);
-        localStorage.removeItem(STORAGE_KEY);
+        storage.removeItem(STORAGE_KEY);
       }
     } catch (e) {
       console.error('Failed to parse stored config:', e);
-      localStorage.removeItem(STORAGE_KEY);
+      storage.removeItem(STORAGE_KEY);
     }
   }
-  // Default to first option (Local)
-  return {
-    environment: ENVIRONMENT_OPTIONS[0],
-  };
+  return { environment: ENVIRONMENT_OPTIONS[0] };
 };
 
 export const ConfigurationScreen = ({ onConfirm }: ConfigurationScreenProps) => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -5,45 +5,40 @@
 
 const STORAGE_KEY = 'app_environment_config';
 
-/**
- * Get valid environment URLs based on current mode
- */
+// In DEV mode use sessionStorage so preferences reset each browser session,
+// ensuring localhost is always the default when running locally.
+const getStorage = (): Storage => (import.meta.env.DEV ? sessionStorage : localStorage);
+
 const getValidUrls = (): string[] => {
-  const localUrl = import.meta.env.VITE_API_LOCAL_URL ||
-                   (import.meta.env.DEV ? import.meta.env.VITE_API_BASE_URL : 'http://localhost:5173');
+  const localUrl = import.meta.env.VITE_API_LOCAL_URL || 'http://localhost:5173';
   const devUrl = 'https://api.dev2.workfloow.app';
   const prodUrl = import.meta.env.VITE_API_PRODUCTION_URL || 'https://api.workfloow.app';
   return [localUrl, devUrl, prodUrl];
 };
 
-/**
- * Get API base URL from localStorage override or fallback to env variable
- */
 const getApiBaseUrl = (): string => {
-  // Default to local URL in development mode, production URL in production mode
+  const localUrl = import.meta.env.VITE_API_LOCAL_URL || 'http://localhost:5173';
   const defaultUrl = import.meta.env.VITE_API_BASE_URL ||
-    (import.meta.env.DEV ? 'http://localhost:5173' : 'https://api.dev2.workfloow.app');
+    (import.meta.env.DEV ? localUrl : 'https://api.dev2.workfloow.app');
 
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const storage = getStorage();
+    const stored = storage.getItem(STORAGE_KEY);
     if (stored) {
       const config = JSON.parse(stored);
       if (config?.environment?.value) {
         const validUrls = getValidUrls();
-
-        // Validate that stored URL is one of the valid options
         if (validUrls.includes(config.environment.value)) {
           return config.environment.value;
         } else {
-          // Clear invalid stored config
           console.warn('Stored config has invalid URL, clearing:', config.environment.value);
-          localStorage.removeItem(STORAGE_KEY);
+          storage.removeItem(STORAGE_KEY);
         }
       }
     }
   } catch (e) {
     console.error('Failed to parse stored config:', e);
-    localStorage.removeItem(STORAGE_KEY);
+    getStorage().removeItem(STORAGE_KEY);
   }
 
   return defaultUrl;


### PR DESCRIPTION
…lt API

When running locally, previously saved prod/dev environment preferences persisted in localStorage across sessions, causing the app to call the production API by default. Switching to sessionStorage in DEV mode ensures each new browser session starts fresh with the localhost API. The CCC modal override still works — it survives page reloads within the same session via sessionStorage. Also fixed a bug where the Local URL resolved to an empty string when VITE_API_LOCAL_URL and VITE_API_BASE_URL were both unset.