### PR TITLE
feat(estimates): approve/reject icons, doc auto-purge, all-time invoiced

### DIFF
--- a/src/pages/company/CompanyPage.tsx
+++ b/src/pages/company/CompanyPage.tsx
@@ -40,9 +40,10 @@ export const CompanyPage: React.FC = () => {
           </Box>
         ) : (
           <>
-            <SummaryBox label="Waiting Approval" value={summary?.waitingApprovalValue} color="#F59E0B" fmt={fmt} />
-            <SummaryBox label="Approved" value={summary?.approvedValue} color="#10B981" fmt={fmt} />
-            <SummaryBox label="Invoiced" value={summary?.invoicedValue} color="#6366F1" fmt={fmt} />
+            <SummaryBox label="Waiting Approval (WIP)" value={summary?.waitingApprovalValue} color="#F59E0B" fmt={fmt} />
+            <SummaryBox label="Approved (WIP)" value={summary?.approvedValue} color="#10B981" fmt={fmt} />
+            <SummaryBox label="Invoiced (WIP)" value={summary?.invoicedValue} color="#6366F1" fmt={fmt} />
+            <SummaryBox label="All-Time Invoiced" value={summary?.allTimeInvoicedValue} color="#0EA5E9" fmt={fmt} />
           </>
         )}
       </Box>

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobEstimateTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobEstimateTab.tsx
@@ -271,8 +271,25 @@ export const JobEstimateTab: React.FC<JobEstimateTabProps> = ({ job }) => {
         status: LineItemStatusUpdateRequestStatusEnum.Approved,
       });
       setEstimate(res.data);
+      await fetchEstimateDocs(estimate.id);
     } catch {
       showError('Failed to approve item');
+    } finally {
+      setApprovingIds((prev) => { const next = new Set(prev); next.delete(itemId); return next; });
+    }
+  };
+
+  const handleRejectItem = async (itemId: number) => {
+    if (!estimate?.id) return;
+    setApprovingIds((prev) => new Set(prev).add(itemId));
+    try {
+      const res = await estimateService.updateLineItemStatus(estimate.id, itemId, {
+        status: LineItemStatusUpdateRequestStatusEnum.Available,
+      });
+      setEstimate(res.data);
+      await fetchEstimateDocs(estimate.id);
+    } catch {
+      showError('Failed to reject item');
     } finally {
       setApprovingIds((prev) => { const next = new Set(prev); next.delete(itemId); return next; });
     }
@@ -878,18 +895,32 @@ export const JobEstimateTab: React.FC<JobEstimateTabProps> = ({ job }) => {
                       <ActionsCell sx={CC} onClick={(e) => e.stopPropagation()}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                           {status === 'WAITING_APPROVAL' && (
-                            <Tooltip title="Approve">
-                              <span>
-                                <Button
-                                  variant="contained" color="success"
-                                  disabled={isApproving}
-                                  onClick={() => handleApproveItem(item.id!)}
-                                  sx={{ minWidth: 0, padding: '2px 8px', fontSize: '0.7rem', height: 24 }}
-                                >
-                                  {isApproving ? <CircularProgress size={10} /> : 'Approve'}
-                                </Button>
-                              </span>
-                            </Tooltip>
+                            isApproving ? (
+                              <CircularProgress size={14} />
+                            ) : (
+                              <>
+                                <Tooltip title="Approve">
+                                  <IconButton
+                                    size="small"
+                                    onClick={() => handleApproveItem(item.id!)}
+                                    aria-label="Approve line item"
+                                    sx={{ color: 'success.main', p: 0.25 }}
+                                  >
+                                    <CheckIcon sx={{ fontSize: '1.1rem' }} />
+                                  </IconButton>
+                                </Tooltip>
+                                <Tooltip title="Reject">
+                                  <IconButton
+                                    size="small"
+                                    onClick={() => handleRejectItem(item.id!)}
+                                    aria-label="Reject line item"
+                                    sx={{ color: 'error.main', p: 0.25 }}
+                                  >
+                                    <CloseIcon sx={{ fontSize: '1.1rem' }} />
+                                  </IconButton>
+                                </Tooltip>
+                              </>
+                            )
                           )}
                           {!invoiced && (
                             <IconButton size="small" onClick={(e) => handleMenuOpen(e, item.id!)} aria-label="Line item actions">

--- a/workflow-api/api.ts
+++ b/workflow-api/api.ts
@@ -394,6 +394,7 @@ export interface FinancialSummaryResponse {
     'waitingApprovalValue'?: number;
     'approvedValue'?: number;
     'invoicedValue'?: number;
+    'allTimeInvoicedValue'?: number;
 }
 export interface ForgotPasswordRequest {
     'email': string;


### PR DESCRIPTION
- Replace Approve button with green tick + red cross IconButtons on WAITING_APPROVAL line items
- Add handleRejectItem (sets status back to AVAILABLE)
- Re-fetch estimate documents after approve/reject (backend may purge empty docs)
- Add allTimeInvoicedValue field to FinancialSummaryResponse + dashboard card
- Mark Waiting Approval / Approved / Invoiced labels with (WIP) suffix