### PR TITLE
feat(workflow-builder): redesign step list as connected stepper

### DIFF
--- a/src/components/UI/PageWrapper/PageWrapper.styles.ts
+++ b/src/components/UI/PageWrapper/PageWrapper.styles.ts
@@ -7,68 +7,105 @@ interface PageContainerProps {
 
 export const PageContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'maxWidth',
-})<PageContainerProps>(({ theme: { spacing }, maxWidth }) => ({
+})<PageContainerProps>(({ theme, maxWidth }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
   maxWidth: maxWidth || '100%',
   margin: '0 auto',
-  padding: spacing(1),
+  padding: theme.spacing(1),
+
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(0.75),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    padding: theme.spacing(0.5),
+  },
 }));
 
-export const PageHeader = styled(Box)(({ theme: { spacing, palette } }) => ({
+export const PageHeader = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  padding: spacing(2.5),
-  gap: spacing(1.5),
-  background: palette.colors?.white || palette.background.paper || '#FFFFFF',
+  padding: theme.spacing(2.5),
+  gap: theme.spacing(1.5),
+  background: theme.palette.colors?.white || theme.palette.background.paper,
   borderRadius: '8px 8px 0px 0px',
   width: '100%',
+  boxSizing: 'border-box',
+
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(2),
+    gap: theme.spacing(1),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    padding: theme.spacing(1.5),
+    gap: theme.spacing(1),
+  },
 }));
 
-export const HeaderContent = styled(Box)(() => ({
+export const HeaderContent = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-  padding: 0,
   gap: rem(12),
   width: '100%',
-  flex: 'none',
-  order: 0,
-  alignSelf: 'stretch',
-  flexGrow: 0,
+
+  [theme.breakpoints.down('md')]: {
+    flexWrap: 'wrap',
+    gap: rem(10),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: rem(10),
+  },
 }));
 
-export const HeaderLeft = styled(Box)(({ theme: { spacing } }) => ({
+export const HeaderLeft = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  padding: 0,
-  margin: '0 auto',
-  gap: spacing(1),
-  flex: 'none',
-  order: 0,
-  flexGrow: 1,
-  minWidth: 0,
+  gap: theme.spacing(0.5),
+  flex: 1,
+  minWidth: 0, // allows text children to truncate
+
+  [theme.breakpoints.down('md')]: {
+    flex: '1 1 0',
+    minWidth: rem(160),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    width: '100%',
+    flex: 'none',
+  },
 }));
 
-export const HeaderRight = styled(Box)(({ theme: { spacing } }) => ({
+export const HeaderRight = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-  justifyContent: 'flex-end',
   alignItems: 'center',
-  padding: 0,
-  gap: spacing(1.5),
-  margin: '0 auto',
-  flex: 'none',
-  order: 1,
-  flexGrow: 0,
+  gap: theme.spacing(1.5),
   flexShrink: 0,
+  flexWrap: 'wrap',
+
+  [theme.breakpoints.down('md')]: {
+    gap: theme.spacing(1),
+    justifyContent: 'flex-end',
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    width: '100%',
+    justifyContent: 'flex-start',
+    gap: theme.spacing(1),
+  },
 }));
 
-export const Title = styled('h1')(({ theme: { palette } }) => ({
+export const Title = styled('h1')(({ theme }) => ({
   margin: `${rem(-2)} 0`,
   fontFamily: 'Manrope',
   fontStyle: 'normal',
@@ -76,10 +113,24 @@ export const Title = styled('h1')(({ theme: { palette } }) => ({
   fontSize: rem(24),
   lineHeight: rem(33),
   letterSpacing: '0.005em',
-  color: palette.colors?.grey_900 || '#262626',
+  color: theme.palette.colors?.grey_900 || theme.palette.text.primary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '100%',
+
+  [theme.breakpoints.down('md')]: {
+    fontSize: rem(20),
+    lineHeight: rem(28),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: rem(18),
+    lineHeight: rem(24),
+  },
 }));
 
-export const Description = styled('p')(({ theme: { palette } }) => ({
+export const Description = styled('p')(({ theme }) => ({
   margin: 0,
   fontFamily: 'Manrope',
   fontStyle: 'normal',
@@ -87,44 +138,80 @@ export const Description = styled('p')(({ theme: { palette } }) => ({
   fontSize: rem(16),
   lineHeight: rem(24),
   letterSpacing: '0.005em',
-  color: palette.colors?.grey_400 || '#A1A1A1',
+  color: theme.palette.colors?.grey_400 || theme.palette.text.secondary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '100%',
+
+  [theme.breakpoints.down('md')]: {
+    fontSize: rem(14),
+    lineHeight: rem(20),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: rem(13),
+    lineHeight: rem(18),
+  },
 }));
 
-export const FilterButton = styled(Box)(({ theme: { palette } }) => ({
+export const FilterButton = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: 48,
-  height: 48,
-  borderRadius: 6,
-  border: `1px solid ${palette.colors?.grey_100 || palette.border?.main || '#F5F5F5'}`,
+  width: rem(48),
+  height: rem(48),
+  borderRadius: rem(6),
+  border: `1px solid ${theme.palette.colors?.grey_100 || theme.palette.divider}`,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
-  background: palette.colors?.white || palette.background.paper || '#FFFFFF',
+  background: theme.palette.colors?.white || theme.palette.background.paper,
+  flexShrink: 0,
 
   '&:hover': {
-    borderColor: palette.colors?.grey_200 || palette.border?.dark || '#E5E5E5',
-    background: palette.colors?.grey_50 || palette.background.default || '#FAFAFA',
+    borderColor: theme.palette.colors?.grey_200 || theme.palette.grey[200],
+    background: theme.palette.colors?.grey_50 || theme.palette.grey[50],
   },
 
   '&:active': {
     transform: 'scale(0.98)',
   },
+
+  [theme.breakpoints.down('sm')]: {
+    width: rem(40),
+    height: rem(40),
+  },
 }));
 
-export const PageContent = styled(Box)(({ theme: { palette, spacing } }) => ({
+export const PageContent = styled(Box)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  background: palette.colors?.white || palette.background.paper || '#FFFFFF',
+  background: theme.palette.colors?.white || theme.palette.background.paper,
   borderRadius: '0px 0px 8px 8px',
-  minHeight: 200,
-  padding: `0 ${spacing(2.5)}`,
-  paddingBottom: spacing(2.5),
+  minHeight: rem(200),
+  padding: `0 ${theme.spacing(2.5)}`,
+  paddingBottom: theme.spacing(2.5),
+  boxSizing: 'border-box',
+
+  [theme.breakpoints.down('md')]: {
+    padding: `0 ${theme.spacing(2)}`,
+    paddingBottom: theme.spacing(2),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    padding: `0 ${theme.spacing(1.5)}`,
+    paddingBottom: theme.spacing(1.5),
+  },
 }));
 
-export const DropdownWrapper = styled(Box)({
-  minWidth: 200,
+export const DropdownWrapper = styled(Box)(({ theme }) => ({
+  minWidth: rem(200),
   display: 'flex',
   alignItems: 'center',
-});
+
+  [theme.breakpoints.down('sm')]: {
+    minWidth: rem(160),
+    width: '100%',
+  },
+}));

--- a/src/enums/WorkflowStepColors.ts
+++ b/src/enums/WorkflowStepColors.ts
@@ -1,0 +1,11 @@
+import { floowColors } from '../theme/colors';
+
+export const STEP_COLORS = [
+  floowColors.blue.light,
+  floowColors.success.main,
+  floowColors.warning.main,
+  floowColors.indigo.main,
+  floowColors.chart.quinary,
+  floowColors.error.main,
+  floowColors.grey[500],
+] as const;

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -2,3 +2,4 @@ export { FeatureName } from './FeatureName';
 export { FieldType, FIELD_TYPE_OPTIONS } from './FieldType';
 export { JOB_STATUS_OPTIONS } from './JobStatus';
 export { FEATURE_DESCRIPTIONS, DEFAULT_AUTH_FEATURES, DEFAULT_AUTH_TAGLINE } from './features';
+export { STEP_COLORS } from './WorkflowStepColors';

--- a/src/pages/workflows/WorkflowBuilderPage.styles.ts
+++ b/src/pages/workflows/WorkflowBuilderPage.styles.ts
@@ -1,323 +1,383 @@
-import { styled, Box } from '@mui/material';
+import { styled, Box, IconButton, Menu, MenuItem } from '@mui/material';
 import { rem, Bold } from '../../components/UI/Typography/utility';
 import { floowColors } from '../../theme/colors';
 
-// Main container
-export const BuilderContainer = styled(Box)(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: rem(24),
-  width: '100%',
+export { STEP_COLORS } from '../../enums';
+
+// ─── Main card ────────────────────────────────────────────────────────────────
+
+export const StepsCard = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  borderRadius: rem(16),
+  border: `1px solid ${floowColors.slate.light}`,
+  overflow: 'hidden',
+
+  [theme.breakpoints.down('sm')]: {
+    borderRadius: rem(10),
+  },
 }));
 
-// Section wrapper
-export const Section = styled(Box)(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: rem(16),
+// ─── Card header ──────────────────────────────────────────────────────────────
+
+export const StepsCardHeader = styled(Box)(({ theme }) => ({
+  padding: `${rem(20)} ${rem(22)}`,
+  borderBottom: `1px solid ${floowColors.slate.light}`,
+
+  [theme.breakpoints.down('md')]: {
+    padding: `${rem(16)} ${rem(18)}`,
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    padding: `${rem(14)} ${rem(14)}`,
+  },
 }));
 
-export const SectionTitle = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(16),
-  fontWeight: Bold._600,
-  color: palette.text.primary,
-}));
-
-export const SectionDescription = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(14),
-  color: palette.grey[500],
-}));
-
-// Available Steps List (Source)
-export const AvailableStepsList = styled(Box)(({ theme: { palette } }) => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: rem(12),
-  padding: rem(16),
-  backgroundColor: palette.grey[50],
-  borderRadius: rem(8),
-  border: `1px solid ${palette.grey[200]}`,
-  minHeight: rem(80),
-}));
-
-// Step Item (Small card in source list)
-export const StepItem = styled(Box)(({ theme: { palette } }) => ({
+export const StepsCardTitleRow = styled(Box)(() => ({
   display: 'flex',
   alignItems: 'center',
-  gap: rem(8),
-  padding: `${rem(8)} ${rem(12)}`,
-  backgroundColor: palette.background.paper,
-  borderRadius: rem(6),
-  border: `1px solid ${palette.grey[300]}`,
-  cursor: 'grab',
-  transition: 'all 0.2s',
+  gap: rem(10),
+}));
 
-  '&:hover': {
-    borderColor: palette.grey[400],
-    boxShadow: '0 2px 4px ${floowColors.shadow.lg}',
+export const StepsCardTitle = styled('h2')(({ theme }) => ({
+  margin: 0,
+  fontSize: rem(16),
+  fontWeight: Bold._700,
+  color: theme.palette.text.primary,
+  lineHeight: 1.4,
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: rem(15),
+  },
+}));
+
+export const StepsCountBadge = styled(Box)(({ theme }) => ({
+  fontSize: rem(12),
+  fontWeight: Bold._700,
+  color: theme.palette.grey[600],
+  backgroundColor: floowColors.grey[100],
+  borderRadius: rem(20),
+  padding: `${rem(2)} ${rem(9)}`,
+  lineHeight: 1.5,
+}));
+
+export const StepsCardSubtitle = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(6),
+  fontSize: rem(12),
+  color: theme.palette.grey[500],
+  marginTop: rem(6),
+  '& svg': {
+    fontSize: rem(13),
+    flexShrink: 0,
+  },
+}));
+
+// ─── Rail wrapper ─────────────────────────────────────────────────────────────
+// Rail left = paddingLeft + col1(18) + gap(14) + col2Half(18) = paddingLeft + 50.
+// Default 22 + 50 = 72 | md 18 + 50 = 68 | sm 14 + 50 = 64
+
+export const StepsRailWrapper = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  paddingTop: 0,
+  paddingRight: rem(22),
+  paddingBottom: rem(20),
+  paddingLeft: rem(22),
+
+  [theme.breakpoints.down('md')]: {
+    paddingRight: rem(18),
+    paddingBottom: rem(16),
+    paddingLeft: rem(18),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    paddingRight: rem(14),
+    paddingBottom: rem(14),
+    paddingLeft: rem(14),
+  },
+}));
+
+export const StepsRail = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  left: rem(72),
+  top: rem(26),
+  bottom: rem(30),
+  width: rem(2),
+  backgroundColor: floowColors.slate.light,
+  borderRadius: rem(2),
+  zIndex: 0,
+
+  [theme.breakpoints.down('md')]: {
+    left: rem(68),
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    left: rem(64),
+  },
+}));
+
+// ─── Steps list ───────────────────────────────────────────────────────────────
+
+export const StepsList = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(6),
+}));
+
+// ─── Step row ─────────────────────────────────────────────────────────────────
+// Hover effects target children via named CSS classes:
+//   .step-drag-grip → opacity 1
+//   .step-card-body → lighter background
+//   .step-kebab     → muted background
+
+export const StepRow = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '18px 36px 1fr 28px',
+  alignItems: 'start',
+  gap: rem(14),
+  padding: `${rem(10)} 0`,
+  position: 'relative',
+
+  '&:hover .step-drag-grip': {
+    opacity: 1,
+  },
+
+  '&:hover .step-card-body': {
+    backgroundColor: floowColors.tailwind.gray[50],
+  },
+
+  '&:hover .step-kebab': {
+    backgroundColor: floowColors.grey[100],
   },
 
   '&.dragging': {
     opacity: 0.5,
-    cursor: 'grabbing',
   },
 
-  '&.in-order': {
-    backgroundColor: palette.success.light,
-    borderColor: palette.success.main,
+  [theme.breakpoints.down('sm')]: {
+    gridTemplateColumns: '16px 32px 1fr 24px',
+    gap: rem(10),
   },
 }));
 
-export const StepItemName = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(14),
-  fontWeight: Bold._500,
-  color: palette.text.primary,
-}));
+// ─── Drag grip ────────────────────────────────────────────────────────────────
 
-export const StepItemActions = styled(Box)(() => ({
+export const StepDragGrip = styled(Box)(() => ({
   display: 'flex',
-  alignItems: 'center',
-  gap: rem(4),
-  marginLeft: rem(8),
-}));
-
-// Workflow Order Box (Target - horizontal)
-export const WorkflowOrderBox = styled(Box)(({ theme: { palette } }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-  padding: rem(20),
-  backgroundColor: palette.background.paper,
-  borderRadius: rem(12),
-  border: `2px dashed ${palette.grey[300]}`,
-  minHeight: rem(120),
-  overflowX: 'auto',
-  transition: 'all 0.2s',
-
-  '&:empty::before': {
-    content: '"Drag steps here to set the order"',
-    color: palette.grey[400],
-    fontSize: rem(14),
-  },
-
-  '&.drag-over': {
-    borderColor: palette.primary.main,
-    backgroundColor: palette.primary.light || '${floowColors.shadow.xs}',
-  },
-}));
-
-// Ordered Step Card (in the workflow order box)
-export const OrderedStepCard = styled(Box)(({ theme: { palette } }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
   justifyContent: 'center',
-  padding: rem(16),
-  backgroundColor: palette.background.paper,
-  borderRadius: rem(8),
-  border: `1px solid ${palette.grey[300]}`,
-  minWidth: rem(140),
-  maxWidth: rem(180),
+  paddingTop: rem(9),
   cursor: 'grab',
-  transition: 'all 0.2s',
+  opacity: 0.45,
+  transition: 'opacity 0.15s',
+  color: floowColors.slate.main,
   flexShrink: 0,
 
-  '&:hover': {
-    borderColor: palette.primary.main,
-    boxShadow: '0 2px 8px ${floowColors.shadow.xl}',
-  },
-
-  '&.dragging': {
-    opacity: 0.5,
+  '&:active': {
     cursor: 'grabbing',
   },
 }));
 
-export const OrderedStepHeader = styled(Box)(() => ({
+// ─── Number badge column ──────────────────────────────────────────────────────
+
+export const StepNumberColumn = styled(Box)(() => ({
   display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  width: '100%',
-  marginBottom: rem(8),
+  justifyContent: 'center',
+  alignItems: 'flex-start',
+  paddingTop: rem(9),
+  flexShrink: 0,
 }));
 
-export const OrderedStepNumber = styled(Box)(({ theme: { palette } }) => ({
-  width: rem(28),
-  height: rem(28),
+// ─── Numbered colored circle ──────────────────────────────────────────────────
+// box-shadow ring creates the white halo + color shadow without affecting layout.
+
+export const StepNumberBadge = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'stepcolor',
+})<{ stepcolor: string }>(({ stepcolor }) => ({
+  width: rem(32),
+  height: rem(32),
   borderRadius: '50%',
-  backgroundColor: palette.common.black,
-  color: palette.common.white,
+  backgroundColor: stepcolor,
+  color: floowColors.white,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontWeight: Bold._600,
-  fontSize: rem(12),
+  fontWeight: Bold._700,
+  fontSize: rem(14),
+  flexShrink: 0,
+  userSelect: 'none',
+  position: 'relative',
+  zIndex: 1,
+  lineHeight: 1,
+  boxShadow: `0 0 0 3px ${floowColors.white}, 0 0 0 5px ${stepcolor}33, 0 2px 6px ${stepcolor}33`,
 }));
 
-export const OrderedStepName = styled(Box)(({ theme: { palette } }) => ({
+// ─── Step inner card (col 3) ──────────────────────────────────────────────────
+
+export const StepCardBody = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'stepcolor',
+})<{ stepcolor: string }>(({ theme, stepcolor }) => ({
+  flex: 1,
+  minWidth: 0,
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${floowColors.slate.light}`,
+  borderLeft: `3px solid ${stepcolor}`,
+  borderRadius: rem(10),
+  padding: `${rem(11)} ${rem(14)}`,
+  transition: 'background-color 0.15s',
+
+  [theme.breakpoints.down('sm')]: {
+    padding: `${rem(8)} ${rem(10)}`,
+    borderRadius: rem(8),
+  },
+}));
+
+export const StepTitleRow = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+  flexWrap: 'wrap',
+}));
+
+export const StepTitle = styled(Box)(({ theme }) => ({
   fontSize: rem(14),
-  fontWeight: Bold._500,
-  color: palette.text.primary,
-  textAlign: 'center',
+  fontWeight: Bold._700,
+  color: theme.palette.text.primary,
+  lineHeight: 1.4,
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: rem(13),
+  },
+}));
+
+export const StepDescription = styled(Box)(() => ({
+  fontSize: rem(13),
+  color: floowColors.slate.dark,
+  lineHeight: 1.5,
+  marginTop: rem(4),
   wordBreak: 'break-word',
 }));
 
-export const OrderedStepDescription = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(12),
-  color: palette.grey[500],
-  textAlign: 'center',
-  marginTop: rem(4),
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  display: '-webkit-box',
-  WebkitLineClamp: 2,
-  WebkitBoxOrient: 'vertical',
-}));
+// ─── Kebab (3-dot) button ─────────────────────────────────────────────────────
 
-// Arrow connector between ordered steps
-export const StepConnector = styled(Box)(({ theme: { palette } }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: palette.grey[400],
-  fontSize: rem(24),
+export const StepKebabButton = styled(IconButton)(() => ({
+  borderRadius: rem(7),
+  padding: rem(6),
   flexShrink: 0,
-  padding: `0 ${rem(4)}`,
+  paddingTop: rem(9),
+  transition: 'background-color 0.15s',
+  alignSelf: 'start',
 }));
 
-// Empty state for workflow order
-export const EmptyOrderState = styled(Box)(({ theme: { palette } }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '100%',
-  color: palette.grey[400],
-  fontSize: rem(14),
-}));
+// ─── Context menu ─────────────────────────────────────────────────────────────
 
-// Empty state (no steps created)
-export const EmptyState = styled(Box)(({ theme: { palette } }) => ({
-  textAlign: 'center',
-  padding: `${rem(48)} ${rem(24)}`,
-  backgroundColor: palette.grey[50],
-  borderRadius: rem(12),
-  border: `1px dashed ${palette.grey[300]}`,
-}));
-
-export const EmptyStateTitle = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(18),
-  fontWeight: Bold._600,
-  color: palette.grey[600],
-  marginBottom: rem(8),
-}));
-
-export const EmptyStateDescription = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(14),
-  color: palette.grey[500],
-}));
-
-// Legacy exports for backwards compatibility
-export const StepsContainer = styled(Box)(() => ({
-  width: '100%',
-}));
-
-export const StepCard = styled(Box)(({ theme: { palette } }) => ({
-  background: palette.background.paper,
-  border: `1px solid ${palette.divider}`,
-  borderRadius: rem(8),
-  padding: rem(16),
-  minWidth: rem(250),
-  maxWidth: rem(280),
-  display: 'flex',
-  flexDirection: 'column',
-  gap: rem(12),
-  cursor: 'grab',
-  transition: 'all 0.2s',
-  position: 'relative',
-
-  '&:hover': {
-    borderColor: palette.primary.main,
-    boxShadow: '0 2px 8px ${floowColors.shadow.xl}',
-  },
-
-  '&.dragging': {
-    opacity: 0.5,
-    cursor: 'grabbing',
+export const StepContextMenu = styled(Menu)(({ theme }) => ({
+  '& .MuiPaper-root': {
+    minWidth: rem(140),
+    boxShadow: `0 4px 16px ${floowColors.shadow.card}`,
+    borderRadius: rem(8),
+    border: `1px solid ${theme.palette.grey[100]}`,
   },
 }));
 
-export const StepContent = styled(Box)(() => ({
-  flex: 1,
-}));
-
-export const StepActions = styled(Box)(() => ({
+export const StepEditMenuItem = styled(MenuItem)(({ theme }) => ({
   display: 'flex',
   gap: rem(8),
-  justifyContent: 'flex-end',
+  fontSize: rem(14),
+  color: theme.palette.text.primary,
+  '& svg': {
+    fontSize: rem(18),
+    color: theme.palette.text.secondary,
+  },
 }));
 
-export const StepHeader = styled(Box)(() => ({
+export const StepDeleteMenuItem = styled(MenuItem)(({ theme }) => ({
   display: 'flex',
+  gap: rem(8),
+  fontSize: rem(14),
+  color: theme.palette.error.main,
+  '& svg': {
+    fontSize: rem(18),
+  },
+}));
+
+// ─── Add-step node (end of rail) ──────────────────────────────────────────────
+
+export const AddNodeWrapper = styled('button')(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '18px 36px 1fr',
   alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: rem(8),
+  gap: rem(14),
+  paddingTop: rem(8),
+  cursor: 'pointer',
+  background: 'none',
+  border: 'none',
+  textAlign: 'left',
+  width: '100%',
+  padding: `${rem(8)} 0 0`,
+
+  '&:hover .add-node-label': {
+    color: theme.palette.text.primary,
+  },
+
+  '&:hover .add-node-circle': {
+    borderColor: theme.palette.grey[400],
+  },
+
+  [theme.breakpoints.down('sm')]: {
+    gridTemplateColumns: '16px 32px 1fr',
+    gap: rem(10),
+  },
 }));
 
-export const StepNumber = styled(Box)(({ theme: { palette } }) => ({
-  minWidth: rem(32),
+export const AddNodeCircle = styled(Box)(({ theme }) => ({
+  width: rem(32),
   height: rem(32),
   borderRadius: '50%',
-  backgroundColor: palette.common.black,
-  color: palette.common.white,
+  backgroundColor: theme.palette.background.paper,
+  border: `2px dashed ${theme.palette.grey[300]}`,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontWeight: Bold._600,
-  fontSize: rem(14),
-}));
-
-export const StepTitle = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(16),
-  fontWeight: Bold._600,
-  color: palette.text.primary,
-  marginBottom: rem(4),
-}));
-
-export const StepOptionalLabel = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(12),
-  color: palette.grey[500],
-  display: 'block',
-  marginBottom: rem(8),
-}));
-
-export const StepDescription = styled(Box)(({ theme: { palette } }) => ({
-  fontSize: rem(14),
-  color: palette.grey[600],
-  marginTop: rem(8),
-}));
-
-export const DragHandle = styled(Box)(() => ({
-  display: 'flex',
-  alignItems: 'center',
-  cursor: 'grab',
-}));
-
-export const StepsScrollContainer = styled(Box)(() => ({
-  overflowX: 'auto',
-  paddingBottom: rem(16),
-}));
-
-export const StepsTrack = styled(Box)(() => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(16),
-  minWidth: 'max-content',
-}));
-
-export const StepConnectorArrow = styled(Box)(({ theme: { palette } }) => ({
-  color: palette.grey[400],
-  fontSize: rem(28),
+  color: theme.palette.grey[400],
+  transition: 'border-color 0.15s',
   flexShrink: 0,
-  display: 'flex',
-  alignItems: 'center',
+  position: 'relative',
+  zIndex: 1,
+
+  [theme.breakpoints.down('sm')]: {
+    width: rem(28),
+    height: rem(28),
+  },
+}));
+
+export const AddNodeLabel = styled(Box)(({ theme }) => ({
+  fontSize: rem(13),
+  fontWeight: Bold._600,
+  color: theme.palette.grey[500],
+  transition: 'color 0.15s',
+}));
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+export const EmptyStepsHint = styled(Box)(({ theme }) => ({
+  fontSize: rem(13),
+  color: theme.palette.grey[400],
+  paddingTop: rem(12),
+  paddingBottom: rem(4),
+  textAlign: 'center',
+}));
+
+// ─── Drag overlay (floating ghost row) ───────────────────────────────────────
+
+export const DragOverlayRow = styled(Box)(() => ({
+  display: 'grid',
+  gridTemplateColumns: '18px 36px 1fr 28px',
+  alignItems: 'start',
+  gap: rem(14),
+  padding: `${rem(10)} ${rem(22)}`,
+  backgroundColor: floowColors.white,
+  borderRadius: rem(10),
+  boxShadow: `0 8px 24px ${floowColors.shadow.card}`,
+  border: `1px solid ${floowColors.slate.light}`,
+  opacity: 0.95,
 }));

--- a/src/pages/workflows/WorkflowBuilderPage.tsx
+++ b/src/pages/workflows/WorkflowBuilderPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Typography, IconButton } from '@mui/material';
+import { Typography } from '@mui/material';
 import {
   DndContext,
   closestCenter,
@@ -8,27 +8,25 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
-  useDroppable,
-  useDraggable,
+  DragOverlay,
   type DragEndEvent,
   type DragStartEvent,
-  DragOverlay,
 } from '@dnd-kit/core';
 import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
-  horizontalListSortingStrategy,
+  verticalListSortingStrategy,
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import DeleteIcon from '@mui/icons-material/Delete';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EditIcon from '@mui/icons-material/Edit';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import CloseIcon from '@mui/icons-material/Close';
+import DeleteIcon from '@mui/icons-material/Delete';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { PageWrapper } from '../../components/UI/PageWrapper';
 import { useSnackbar } from '../../contexts/SnackbarContext';
 import { useFormSubmit } from '../../hooks';
@@ -50,116 +48,97 @@ interface WorkflowStep extends WorkflowStepResponse {
   maximumDurationMinutes?: number;
 }
 
-// Source list item (draggable from source to target)
-interface DraggableStepItemProps {
-  step: WorkflowStep;
-  onEdit: (step: WorkflowStep) => void;
-  onDelete: (stepId: number) => void;
-  isInOrder: boolean;
-}
+// ─── Sortable step row ────────────────────────────────────────────────────────
 
-const DraggableStepItem: React.FC<DraggableStepItemProps> = ({ step, onEdit, onDelete, isInOrder }) => {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: `source-${step.id}`,
-    data: { type: 'source', step },
-  });
-
-  const handleEditClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onEdit(step);
-  };
-
-  const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onDelete(step.id);
-  };
-
-  return (
-    <S.StepItem
-      ref={setNodeRef}
-      {...attributes}
-      {...listeners}
-      className={`${isDragging ? 'dragging' : ''} ${isInOrder ? 'in-order' : ''}`}
-    >
-      <S.DragHandle>
-        <DragIndicatorIcon fontSize="small" />
-      </S.DragHandle>
-      <S.StepItemName>{step.name}</S.StepItemName>
-      {step.optional && <S.StepOptionalLabel>(Optional)</S.StepOptionalLabel>}
-      <S.StepItemActions>
-        <IconButton size="small" onClick={handleEditClick} aria-label="Edit step">
-          <EditIcon fontSize="small" />
-        </IconButton>
-        <IconButton size="small" onClick={handleDeleteClick} aria-label="Delete step">
-          <DeleteIcon fontSize="small" />
-        </IconButton>
-      </S.StepItemActions>
-    </S.StepItem>
-  );
-};
-
-// Target list item (sortable within target list)
 interface SortableStepItemProps {
   step: WorkflowStep;
   index: number;
-  onRemove: (stepId: number) => void;
+  onEdit: (step: WorkflowStep) => void;
+  onDelete: (stepId: number) => void;
 }
 
-const SortableStepItem: React.FC<SortableStepItemProps> = ({ step, index, onRemove }) => {
+const SortableStepItem: React.FC<SortableStepItemProps> = ({ step, index, onEdit, onDelete }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `order-${step.id}`,
     data: { type: 'order', step },
   });
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const menuOpen = Boolean(anchorEl);
+
+  // dnd-kit requires inline style for the CSS transform — cannot be a styled-component
+  const dndStyle = { transform: CSS.Transform.toString(transform), transition };
+
+  const stepColor = S.STEP_COLORS[index % S.STEP_COLORS.length];
+
+  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleMenuClose = () => setAnchorEl(null);
+
+  const handleEdit = () => {
+    handleMenuClose();
+    onEdit(step);
+  };
+
+  const handleDelete = () => {
+    handleMenuClose();
+    onDelete(step.id);
   };
 
   return (
-    <S.OrderedStepCard
-      ref={setNodeRef}
-      style={style}
-      className={isDragging ? 'dragging' : ''}
-    >
-      <S.OrderedStepHeader>
-        <S.DragHandle {...attributes} {...listeners}>
-          <DragIndicatorIcon fontSize="small" />
-        </S.DragHandle>
-        <S.OrderedStepNumber>{index + 1}</S.OrderedStepNumber>
-        <IconButton size="small" onClick={() => onRemove(step.id)} aria-label="Remove step">
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </S.OrderedStepHeader>
-      <S.OrderedStepName>{step.name}</S.OrderedStepName>
-      {step.description && (
-        <S.OrderedStepDescription>{step.description}</S.OrderedStepDescription>
-      )}
-    </S.OrderedStepCard>
+    <S.StepRow ref={setNodeRef} style={dndStyle} className={isDragging ? 'dragging' : ''}>
+      {/* Col 1 — drag grip */}
+      <S.StepDragGrip className="step-drag-grip" {...attributes} {...listeners}>
+        <DragIndicatorIcon fontSize="small" />
+      </S.StepDragGrip>
+
+      {/* Col 2 — numbered circle on the rail */}
+      <S.StepNumberColumn>
+        <S.StepNumberBadge stepcolor={stepColor}>{index + 1}</S.StepNumberBadge>
+      </S.StepNumberColumn>
+
+      {/* Col 3 — step card with colored left border */}
+      <S.StepCardBody className="step-card-body" stepcolor={stepColor}>
+        <S.StepTitleRow>
+          <S.StepTitle>{step.name}</S.StepTitle>
+        </S.StepTitleRow>
+        {step.description && <S.StepDescription>{step.description}</S.StepDescription>}
+      </S.StepCardBody>
+
+      {/* Col 4 — context menu trigger */}
+      <S.StepKebabButton
+        className="step-kebab"
+        size="small"
+        onClick={handleMenuOpen}
+        aria-label="Step options"
+      >
+        <MoreVertIcon fontSize="small" />
+      </S.StepKebabButton>
+
+      <S.StepContextMenu
+        anchorEl={anchorEl}
+        open={menuOpen}
+        onClose={handleMenuClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <S.StepEditMenuItem onClick={handleEdit}>
+          <EditIcon />
+          Edit
+        </S.StepEditMenuItem>
+        <S.StepDeleteMenuItem onClick={handleDelete}>
+          <DeleteIcon />
+          Delete
+        </S.StepDeleteMenuItem>
+      </S.StepContextMenu>
+    </S.StepRow>
   );
 };
 
-// Droppable area for workflow order
-interface DroppableOrderAreaProps {
-  children: React.ReactNode;
-  isEmpty: boolean;
-}
-
-const DroppableOrderArea: React.FC<DroppableOrderAreaProps> = ({ children, isEmpty }) => {
-  const { setNodeRef, isOver } = useDroppable({
-    id: 'order-area',
-  });
-
-  return (
-    <S.WorkflowOrderBox ref={setNodeRef} className={isOver ? 'drag-over' : ''}>
-      {isEmpty ? (
-        <S.EmptyOrderState>Drag steps here to set the workflow order</S.EmptyOrderState>
-      ) : (
-        children
-      )}
-    </S.WorkflowOrderBox>
-  );
-};
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export const WorkflowBuilderPage: React.FC = () => {
   const { workflowId } = useParams<{ workflowId: string }>();
@@ -169,37 +148,24 @@ export const WorkflowBuilderPage: React.FC = () => {
 
   const [workflow, setWorkflow] = useState<{ id: number; name: string; description?: string } | null>(null);
   const [steps, setSteps] = useState<WorkflowStep[]>([]);
-  const [orderedSteps, setOrderedSteps] = useState<WorkflowStep[]>([]);
   const [loading, setLoading] = useState(true);
   const { saving, withSaving } = useFormSubmit();
-  const [editingStep, setEditingStep] = useState<WorkflowStep | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 5,
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
   useEffect(() => {
     const fetchWorkflow = async () => {
       if (!workflowId) return;
-
       try {
         setLoading(true);
         const response = await workflowService.getWorkflowWithSteps(Number(workflowId));
         const data = response.data;
 
-        setWorkflow({
-          id: data.id || 0,
-          name: data.name || '',
-          description: data.description,
-        });
+        setWorkflow({ id: data.id || 0, name: data.name || '', description: data.description });
 
         const stepsData = (data.steps || []).map((step, index) => ({
           ...step,
@@ -211,7 +177,6 @@ export const WorkflowBuilderPage: React.FC = () => {
 
         stepsData.sort((a, b) => a.orderIndex - b.orderIndex);
         setSteps(stepsData);
-        setOrderedSteps(stepsData);
       } catch (error) {
         console.error('Error fetching workflow:', error);
         showError('Failed to load workflow');
@@ -230,72 +195,39 @@ export const WorkflowBuilderPage: React.FC = () => {
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     setActiveId(null);
-
     if (!over) return;
 
-    const activeData = active.data.current;
-    const overId = over.id as string;
     const activeIdStr = active.id as string;
+    const overId = over.id as string;
 
-    // Dragging from source list
-    if (activeIdStr.startsWith('source-')) {
-      const draggedStep = activeData?.step as WorkflowStep;
-      if (!draggedStep) return;
-
-      const isAlreadyInOrder = orderedSteps.some((s) => s.id === draggedStep.id);
-      if (isAlreadyInOrder) return;
-
-      // Dropped on the order area (empty or container)
-      if (overId === 'order-area') {
-        setOrderedSteps([...orderedSteps, draggedStep].map((s, i) => ({ ...s, orderIndex: i })));
-        return;
-      }
-
-      // Dropped on an existing ordered step
-      if (overId.startsWith('order-')) {
-        const overIndex = orderedSteps.findIndex((s) => `order-${s.id}` === overId);
-        if (overIndex !== -1) {
-          const newOrderedSteps = [...orderedSteps];
-          newOrderedSteps.splice(overIndex + 1, 0, draggedStep);
-          setOrderedSteps(newOrderedSteps.map((s, i) => ({ ...s, orderIndex: i })));
-        }
-        return;
-      }
-    }
-
-    // Reordering within order list
     if (activeIdStr.startsWith('order-') && overId.startsWith('order-')) {
-      const oldIndex = orderedSteps.findIndex((s) => `order-${s.id}` === activeIdStr);
-      const newIndex = orderedSteps.findIndex((s) => `order-${s.id}` === overId);
-
+      const oldIndex = steps.findIndex((s) => `order-${s.id}` === activeIdStr);
+      const newIndex = steps.findIndex((s) => `order-${s.id}` === overId);
       if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
-        const newOrderedSteps = arrayMove(orderedSteps, oldIndex, newIndex);
-        setOrderedSteps(newOrderedSteps.map((s, i) => ({ ...s, orderIndex: i })));
+        setSteps(arrayMove(steps, oldIndex, newIndex).map((s, i) => ({ ...s, orderIndex: i })));
       }
     }
-  };
-
-  const handleRemoveFromOrder = (stepId: number) => {
-    setOrderedSteps(orderedSteps.filter((s) => s.id !== stepId).map((s, i) => ({ ...s, orderIndex: i })));
   };
 
   const handleCloseModal = () => {
     resetGlobalModalOuterProps();
-    setEditingStep(null);
   };
 
   const handleSaveStep = (stepData: StepFormStep) => {
-    if (editingStep) {
-      const updatedStep = {
-        ...editingStep,
+    // ID-based lookup avoids stale-closure issues — StepForm passes initialStep.id
+    // when editing, or Date.now() for new steps.
+    const existing = steps.find((s) => s.id === stepData.id);
+
+    if (existing) {
+      const updatedStep: WorkflowStep = {
+        ...existing,
         name: stepData.name,
         description: stepData.description,
         optional: stepData.optional,
         expectedDurationMinutes: stepData.expectedDurationMinutes,
         maximumDurationMinutes: stepData.maximumDurationMinutes,
       };
-      setSteps(steps.map((s) => (s.id === editingStep.id ? updatedStep : s)));
-      setOrderedSteps(orderedSteps.map((s) => (s.id === editingStep.id ? updatedStep : s)));
+      setSteps(steps.map((s) => (s.id === stepData.id ? updatedStep : s)));
       showSuccess('Step updated');
     } else {
       const newStep: WorkflowStep = {
@@ -315,7 +247,6 @@ export const WorkflowBuilderPage: React.FC = () => {
   };
 
   const handleAddStep = () => {
-    setEditingStep(null);
     setGlobalModalOuterProps({
       isOpen: true,
       children: <StepForm initialStep={null} onSave={handleSaveStep} isEditing={false} />,
@@ -325,7 +256,6 @@ export const WorkflowBuilderPage: React.FC = () => {
   };
 
   const handleEditStep = (step: WorkflowStep) => {
-    setEditingStep(step);
     setGlobalModalOuterProps({
       isOpen: true,
       children: <StepForm initialStep={step} onSave={handleSaveStep} isEditing={true} />,
@@ -335,8 +265,7 @@ export const WorkflowBuilderPage: React.FC = () => {
   };
 
   const handleDeleteStep = (stepId: number) => {
-    setSteps(steps.filter((s) => s.id !== stepId));
-    setOrderedSteps(orderedSteps.filter((s) => s.id !== stepId).map((s, i) => ({ ...s, orderIndex: i })));
+    setSteps(steps.filter((s) => s.id !== stepId).map((s, i) => ({ ...s, orderIndex: i })));
     showSuccess('Step removed');
   };
 
@@ -348,7 +277,7 @@ export const WorkflowBuilderPage: React.FC = () => {
         const payload: WorkflowBulkUpdateRequest = {
           name: workflow.name,
           description: workflow.description,
-          steps: orderedSteps.map((step) => ({
+          steps: steps.map((step) => ({
             id: step.id > 1000000000000 ? undefined : step.id,
             name: step.name,
             description: step.description,
@@ -360,7 +289,7 @@ export const WorkflowBuilderPage: React.FC = () => {
         };
 
         await workflowService.bulkUpdateWorkflow(Number(workflowId), payload);
-        showSuccess('Workfloow saved successfully');
+        showSuccess('Workflow saved successfully');
 
         const response = await workflowService.getWorkflowWithSteps(Number(workflowId));
         const data = response.data;
@@ -373,7 +302,6 @@ export const WorkflowBuilderPage: React.FC = () => {
         }));
         stepsData.sort((a, b) => a.orderIndex - b.orderIndex);
         setSteps(stepsData);
-        setOrderedSteps(stepsData);
       });
     } catch (error) {
       console.error('Error saving workflow:', error);
@@ -383,39 +311,29 @@ export const WorkflowBuilderPage: React.FC = () => {
 
   const getActiveStep = (): WorkflowStep | null => {
     if (!activeId) return null;
-    const stepId = parseInt(activeId.replace('source-', '').replace('order-', ''));
-    return steps.find((s) => s.id === stepId) || orderedSteps.find((s) => s.id === stepId) || null;
+    const stepId = parseInt(activeId.replace('order-', ''));
+    return steps.find((s) => s.id === stepId) || null;
   };
 
-  if (loading) {
-    return <Loader />;
-  }
+  if (loading) return <Loader />;
+  if (!workflow) return <Typography>Workflow not found</Typography>;
 
-  if (!workflow) {
-    return <Typography>Workfloow not found</Typography>;
-  }
-
-  const orderedStepIds = orderedSteps.map((s) => s.id);
+  const activeStep = getActiveStep();
+  const activeStepIndex = activeStep ? steps.findIndex((s) => s.id === activeStep.id) : -1;
 
   return (
     <PageWrapper
       title={workflow.name}
-      description={workflow.description || 'Build your workfloow by adding and arranging steps'}
+      description={workflow.description || 'Build your workflow by adding and arranging steps'}
       actions={[
         {
-          label: 'Back to Workfloows',
+          label: 'Back to Workflows',
           onClick: () => navigate('/company/workflows'),
           variant: 'outlined',
           icon: <ArrowBackIcon />,
         },
         {
-          label: 'Add Step',
-          onClick: handleAddStep,
-          variant: 'outlined',
-          icon: <AddIcon />,
-        },
-        {
-          label: saving ? 'Saving...' : 'Save Workfloow',
+          label: saving ? 'Saving...' : 'Save Workflow',
           onClick: handleSaveWorkflow,
           variant: 'contained',
           color: 'primary',
@@ -429,59 +347,80 @@ export const WorkflowBuilderPage: React.FC = () => {
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
-        <S.BuilderContainer>
-          {/* Source List - Available Steps */}
-          <S.Section>
-            <S.SectionTitle>Available Steps</S.SectionTitle>
-            <S.SectionDescription>
-              Drag steps from here to the workflow order below
-            </S.SectionDescription>
-            <S.AvailableStepsList>
-              {steps.length === 0 ? (
-                <S.EmptyOrderState>No steps created. Click "Add Step" to create one.</S.EmptyOrderState>
-              ) : (
-                steps.map((step) => (
-                  <DraggableStepItem
+        <S.StepsCard>
+          {/* Header — title, step count pill, drag hint */}
+          <S.StepsCardHeader>
+            <S.StepsCardTitleRow>
+              <S.StepsCardTitle>Workflow Steps</S.StepsCardTitle>
+              <S.StepsCountBadge>
+                {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+              </S.StepsCountBadge>
+            </S.StepsCardTitleRow>
+            <S.StepsCardSubtitle>
+              <InfoOutlinedIcon />
+              Drag the handle to reorder — the flow runs top to bottom
+            </S.StepsCardSubtitle>
+          </S.StepsCardHeader>
+
+          {/* Rail + ordered step list */}
+          <S.StepsRailWrapper>
+            <S.StepsRail />
+
+            <SortableContext
+              items={steps.map((s) => `order-${s.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              <S.StepsList>
+                {steps.map((step, index) => (
+                  <SortableStepItem
                     key={step.id}
                     step={step}
+                    index={index}
                     onEdit={handleEditStep}
                     onDelete={handleDeleteStep}
-                    isInOrder={orderedStepIds.includes(step.id)}
                   />
-                ))
-              )}
-            </S.AvailableStepsList>
-          </S.Section>
-
-          {/* Target List - Workflow Order */}
-          <S.Section>
-            <S.SectionTitle>Workfloow Order</S.SectionTitle>
-            <S.SectionDescription>
-              Drag and drop to reorder steps. This is the order steps will be executed.
-            </S.SectionDescription>
-            <SortableContext items={orderedSteps.map((s) => `order-${s.id}`)} strategy={horizontalListSortingStrategy}>
-              <DroppableOrderArea isEmpty={orderedSteps.length === 0}>
-                {orderedSteps.map((step, index) => (
-                  <React.Fragment key={step.id}>
-                    <SortableStepItem step={step} index={index} onRemove={handleRemoveFromOrder} />
-                    {index < orderedSteps.length - 1 && (
-                      <S.StepConnector>
-                        <ArrowForwardIcon fontSize="inherit" />
-                      </S.StepConnector>
-                    )}
-                  </React.Fragment>
                 ))}
-              </DroppableOrderArea>
+              </S.StepsList>
             </SortableContext>
-          </S.Section>
-        </S.BuilderContainer>
 
+            {steps.length === 0 && (
+              <S.EmptyStepsHint>No steps yet — click below to add your first step</S.EmptyStepsHint>
+            )}
+
+            {/* Single add control — dashed node at the end of the rail */}
+            <S.AddNodeWrapper onClick={handleAddStep}>
+              <span />
+              <S.AddNodeCircle className="add-node-circle">
+                <AddIcon fontSize="small" />
+              </S.AddNodeCircle>
+              <S.AddNodeLabel className="add-node-label">Add step</S.AddNodeLabel>
+            </S.AddNodeWrapper>
+          </S.StepsRailWrapper>
+        </S.StepsCard>
+
+        {/* Drag overlay — floating ghost of the dragged row */}
         <DragOverlay>
-          {activeId && getActiveStep() && (
-            <S.StepItem style={{ opacity: 0.9, boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
-              <DragIndicatorIcon fontSize="small" />
-              <S.StepItemName>{getActiveStep()?.name}</S.StepItemName>
-            </S.StepItem>
+          {activeStep && (
+            <S.DragOverlayRow>
+              <S.StepDragGrip>
+                <DragIndicatorIcon fontSize="small" />
+              </S.StepDragGrip>
+              <S.StepNumberColumn>
+                <S.StepNumberBadge stepcolor={S.STEP_COLORS[activeStepIndex % S.STEP_COLORS.length]}>
+                  {activeStepIndex + 1}
+                </S.StepNumberBadge>
+              </S.StepNumberColumn>
+              <S.StepCardBody
+                stepcolor={S.STEP_COLORS[activeStepIndex % S.STEP_COLORS.length]}
+              >
+                <S.StepTitleRow>
+                  <S.StepTitle>{activeStep.name}</S.StepTitle>
+                </S.StepTitleRow>
+                {activeStep.description && (
+                  <S.StepDescription>{activeStep.description}</S.StepDescription>
+                )}
+              </S.StepCardBody>
+            </S.DragOverlayRow>
           )}
         </DragOverlay>
       </DndContext>


### PR DESCRIPTION
Replaces the flat card rows with a connected stepper layout — a vertical rail line threads through numbered node badges, with each step rendered as an inner card with a colored left border and fully-wrapping description text.

Key changes:
- Single "Add step" dashed-node at end of rail (removes duplicate header/footer add buttons)
- Step number badges sit on the rail via z-index + white halo shadow
- Hover selectively reveals grip opacity, step-card bg, and kebab bg using CSS class selectors (.step-drag-grip / .step-card-body / .step-kebab)
- StepNumberBadge and StepCardBody use shouldForwardProp to prevent custom stepcolor prop from reaching the DOM
- Fix step edit duplication bug: handleSaveStep uses ID-based lookup instead of editingStep state, avoiding stale closure on update
- PageWrapper.styles.ts: responsive header fixes so actions never clip at narrow viewports (flexWrap, title truncation, removed margin: 0 auto)
- STEP_COLORS constant moved to src/enums/WorkflowStepColors.ts