### PR TITLE
feat: implement reusable tooltip system and sidebar new icon

### DIFF
--- a/src/components/UI/TollTip/IToolTip.ts
+++ b/src/components/UI/TollTip/IToolTip.ts
@@ -1,0 +1,3 @@
+export interface TollTipProps {
+  message: string;
+}

--- a/src/components/UI/TollTip/TollTip.tsx
+++ b/src/components/UI/TollTip/TollTip.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Tooltip as MuiTooltip } from '@mui/material';
+import { ToolTipWrapper, StyledInfoIcon } from './ToolTip.styles';
+import type { TollTipProps } from './IToolTip';
+
+export const TollTip: React.FC<TollTipProps> = ({ message }) => {
+  return (
+    <MuiTooltip title={message} arrow placement="top">
+      <ToolTipWrapper>
+        <StyledInfoIcon />
+      </ToolTipWrapper>
+    </MuiTooltip>
+  );
+};

--- a/src/components/UI/TollTip/ToolTip.styles.ts
+++ b/src/components/UI/TollTip/ToolTip.styles.ts
@@ -1,0 +1,13 @@
+import { styled } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+export const ToolTipWrapper = styled('span')(() => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+}));
+
+export const StyledInfoIcon = styled(InfoOutlinedIcon)(({ theme }) => ({
+  fontSize: '1rem',
+  color: theme.palette.text.secondary,
+  cursor: 'pointer',
+}));

--- a/src/components/UI/TopNav/TopNav.tsx
+++ b/src/components/UI/TopNav/TopNav.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { IconButton} from '@mui/material';
-import MenuIcon from '@mui/icons-material/Menu';
 import { TopNavOuterWrapper, TopNavWrapper, RightSection, LeftSection, CenterSection, SearchSection,LogoWrapper} from './TopNav.styles';
 import type { TopNavProps } from './TopNav.types';
 import { FloowLogo } from '../FloowLogo/FloowLogo';
 import { floowColors } from '../../../theme/colors';
+import { SidebarCollapse } from './icon/SidebarCollapse';
+import { SidebarExpand } from './icon/SidebarExpand';
 
 /**
  * TopNav Component
@@ -28,6 +29,7 @@ export const TopNav: React.FC<TopNavProps> = ({
   searchContent,
   rightContent,
   onToggleSidebar,
+  isCollapsed,
   className,
   sx,
 }) => {
@@ -49,7 +51,7 @@ export const TopNav: React.FC<TopNavProps> = ({
             aria-label="Toggle sidebar menu"
             title="Toggle sidebar"
           >
-            <MenuIcon />
+            {isCollapsed ? <SidebarExpand /> : <SidebarCollapse />}
           </IconButton>
         </LeftSection>
 

--- a/src/components/UI/TopNav/TopNav.types.ts
+++ b/src/components/UI/TopNav/TopNav.types.ts
@@ -16,6 +16,11 @@ export interface TopNavProps {
   rightContent?: ReactNode;
 
   /**
+   * Whether the sidebar is currently collapsed
+   */
+  isCollapsed?: boolean;
+
+  /**
    * Callback to toggle sidebar (mobile only)
    */
   onToggleSidebar?: () => void;

--- a/src/components/UI/TopNav/icon/SidebarCollapse.tsx
+++ b/src/components/UI/TopNav/icon/SidebarCollapse.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const SidebarCollapse: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="24" height="24" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect x="0" y="0" width="200" height="200" rx="36" fill="transparent" />
+    <rect x="28" y="50" width="124" height="22" rx="11" fill="#f0f0f0" />
+    <rect x="28" y="89" width="92" height="22" rx="11" fill="#f0f0f0" />
+    <polyline points="163,78 143,100 163,122" fill="none" stroke="#f0f0f0" strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
+    <rect x="28" y="128" width="124" height="22" rx="11" fill="#f0f0f0" />
+  </svg>
+);

--- a/src/components/UI/TopNav/icon/SidebarExpand.tsx
+++ b/src/components/UI/TopNav/icon/SidebarExpand.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const SidebarExpand: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="24" height="24" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect x="0" y="0" width="200" height="200" rx="36" fill="transparent" />
+    <rect x="28" y="50" width="124" height="22" rx="11" fill="#f0f0f0" />
+    <polyline points="37,78 57,100 37,122" fill="none" stroke="#f0f0f0" strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
+    <rect x="68" y="89" width="84" height="22" rx="11" fill="#f0f0f0" />
+    <rect x="28" y="128" width="124" height="22" rx="11" fill="#f0f0f0" />
+  </svg>
+);

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -303,6 +303,7 @@ export const Layout: React.FC = () => {
       <S.PageRightSection>
         {/* Persistent TopNav */}
         <TopNav
+          isCollapsed={isSidebarCollapsed}
           rightContent={
             <>
               {trialDaysLeft !== null && (

--- a/src/pages/company/CompanyPage.styles.ts
+++ b/src/pages/company/CompanyPage.styles.ts
@@ -141,3 +141,44 @@ export const Title = styled(Typography)(({ theme }) => ({
     fontSize: rem(26),
   },
 }));
+
+export const SummaryCardsContainer = styled(Box)(() => ({
+  display: 'flex',
+  gap: rem(16),
+  marginBottom: rem(24),
+  flexWrap: 'wrap',
+}));
+
+export const SummaryLoadingContainer = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+  paddingTop: rem(16),
+  paddingBottom: rem(16),
+}));
+
+export const SummaryHeader = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(4),
+}));
+
+export const SummaryLabelText = styled(Typography)(({ theme }) => ({
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  color: theme.palette.text.secondary,
+}));
+
+interface SummaryValueTextProps {
+  stylecolor: string;
+}
+
+export const SummaryValueText = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'stylecolor',
+})<SummaryValueTextProps>(({ stylecolor }) => ({
+  marginTop: rem(4),
+  fontWeight: 700,
+  color: stylecolor,
+}));

--- a/src/pages/company/CompanyPage.tsx
+++ b/src/pages/company/CompanyPage.tsx
@@ -1,19 +1,35 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { CircularProgress, Typography } from '@mui/material';
 import { JobEventsSection } from './components/JobEventsSection';
-import { PageContainer, SummaryCard } from './CompanyPage.styles';
+import { 
+  PageContainer, 
+  SummaryCard,
+  SummaryCardsContainer,
+  SummaryLoadingContainer,
+  SummaryHeader,
+  SummaryLabelText,
+  SummaryValueText
+} from './CompanyPage.styles';
 import { dashboardService } from '../../services/api';
 import type { FinancialSummaryResponse } from '../../services/api';
 import { useCurrency } from '../../contexts/CurrencyContext';
 
-const SummaryBox: React.FC<{ label: string; value?: number; color: string; fmt: (v?: number | null) => string }> = ({ label, value, color, fmt }) => (
+// Tooltip Imports
+import { TollTip } from '../../components/UI/TollTip/TollTip';
+import { TOOLTIP_MESSAGES } from './const/ToolTipConst';
+
+// Cleaned up component using pure styled-components
+const SummaryBox: React.FC<{ label: string; tooltip?: string; value?: number; color: string; fmt: (v?: number | null) => string }> = ({ label, tooltip, value, color, fmt }) => (
   <SummaryCard accentcolor={color}>
-    <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', fontSize: '0.7rem' }}>
-      {label}
-    </Typography>
-    <Typography variant="h5" fontWeight={700} sx={{ mt: 0.5, color }}>
+    <SummaryHeader>
+      <SummaryLabelText variant="caption">
+        {label}
+      </SummaryLabelText>
+      {tooltip && <TollTip message={tooltip} />}
+    </SummaryHeader>
+    <SummaryValueText variant="h5" stylecolor={color}>
       {fmt(value)}
-    </Typography>
+    </SummaryValueText>
   </SummaryCard>
 );
 
@@ -32,21 +48,21 @@ export const CompanyPage: React.FC = () => {
   return (
     <PageContainer>
       {/* Financial Summary */}
-      <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap' }}>
+      <SummaryCardsContainer>
         {loadingSummary ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+          <SummaryLoadingContainer>
             <CircularProgress size={18} />
             <Typography variant="body2" color="text.secondary">Loading summary...</Typography>
-          </Box>
+          </SummaryLoadingContainer>
         ) : (
           <>
-            <SummaryBox label="Waiting Approval (WIP)" value={summary?.waitingApprovalValue} color="#F59E0B" fmt={fmt} />
-            <SummaryBox label="Approved (WIP)" value={summary?.approvedValue} color="#10B981" fmt={fmt} />
-            <SummaryBox label="Invoiced (WIP)" value={summary?.invoicedValue} color="#6366F1" fmt={fmt} />
+            <SummaryBox label="Waiting Approval (WIP)" tooltip={TOOLTIP_MESSAGES.WAITING_APPROVAL} value={summary?.waitingApprovalValue} color="#F59E0B" fmt={fmt} />
+            <SummaryBox label="Approved (WIP)" tooltip={TOOLTIP_MESSAGES.APPROVED} value={summary?.approvedValue} color="#10B981" fmt={fmt} />
+            <SummaryBox label="Invoiced (WIP)" tooltip={TOOLTIP_MESSAGES.INVOICED} value={summary?.invoicedValue} color="#6366F1" fmt={fmt} />
             <SummaryBox label="All-Time Invoiced" value={summary?.allTimeInvoicedValue} color="#0EA5E9" fmt={fmt} />
           </>
         )}
-      </Box>
+      </SummaryCardsContainer>
 
       <JobEventsSection />
     </PageContainer>

--- a/src/pages/company/const/ToolTipConst.ts
+++ b/src/pages/company/const/ToolTipConst.ts
@@ -1,0 +1,5 @@
+export const TOOLTIP_MESSAGES = {
+  WAITING_APPROVAL: "The combined value of all draft, sent, or pending estimates currently awaiting client or internal approval.",
+  APPROVED: "The gross value of all approved estimates currently in progress, before deducting any interim or progress invoices.",
+  INVOICED: "Active invoices issued to clients"
+};

--- a/src/pages/templates/components/TemplatesList/TemplatesList.styles.ts
+++ b/src/pages/templates/components/TemplatesList/TemplatesList.styles.ts
@@ -1,0 +1,7 @@
+import { styled, Box } from '@mui/material';
+
+export const TitleContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}));

--- a/src/pages/templates/components/TemplatesList/TemplatesList.tsx
+++ b/src/pages/templates/components/TemplatesList/TemplatesList.tsx
@@ -10,6 +10,9 @@ import { useSnackbar } from '../../../../contexts/SnackbarContext';
 import { extractErrorMessage } from '../../../../utils/errorHandler';
 import { generateTemplateColumns, type TemplateTableRow } from './DataColumn';
 import { TemplateForm } from '../TemplateForm/TemplateForm';
+import { TollTip } from '../../../../components/UI/TollTip/TollTip';
+import { TOOLTIP_MESSAGES } from './ToolTipConst';
+import { TitleContainer } from './TemplatesList.styles';
 
 export const TemplatesList: React.FC = () => {
   const [templates, setTemplates] = useState<TemplateTableRow[]>([]);
@@ -272,7 +275,12 @@ export const TemplatesList: React.FC = () => {
 
   return (
     <PageWrapper
-      title="Job Templates"
+      title={
+        <TitleContainer>
+          Job Templates
+          <TollTip message={TOOLTIP_MESSAGES.JOB_TEMPLATES} />
+        </TitleContainer>
+      }
       description="Create and manage job templates with custom fields."
       actions={[
         {

--- a/src/pages/templates/components/TemplatesList/ToolTipConst.ts
+++ b/src/pages/templates/components/TemplatesList/ToolTipConst.ts
@@ -1,0 +1,3 @@
+export const TOOLTIP_MESSAGES = {
+  JOB_TEMPLATES: "Create reusable blueprints with specific custom fields tailored to different job types and workflows."
+};

--- a/src/pages/workflows/components/WorkflowsList/ToolTipConst.ts
+++ b/src/pages/workflows/components/WorkflowsList/ToolTipConst.ts
@@ -1,0 +1,3 @@
+export const TOOLTIP_MESSAGES = {
+  WORKFLOW_TEMPLATES: "Design custom service tracks with sequential steps, set strict time limits for each phase, and assign SLAs where you need them to prevent job delays."
+};

--- a/src/pages/workflows/components/WorkflowsList/WorkflowsList.styles.ts
+++ b/src/pages/workflows/components/WorkflowsList/WorkflowsList.styles.ts
@@ -1,0 +1,7 @@
+import { styled, Box } from '@mui/material';
+
+export const TitleContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}));

--- a/src/pages/workflows/components/WorkflowsList/WorkflowsList.tsx
+++ b/src/pages/workflows/components/WorkflowsList/WorkflowsList.tsx
@@ -10,6 +10,9 @@ import { extractErrorMessage } from '../../../../utils/errorHandler';
 import { workflowColumns } from './DataColumn';
 import type { WorkflowTableRow } from '../../../../types/workflow';
 import { WorkflowForm } from '../WorkflowForm/WorkflowForm';
+import { TollTip } from '../../../../components/UI/TollTip/TollTip';
+import { TOOLTIP_MESSAGES } from './ToolTipConst';
+import { TitleContainer } from './WorkflowsList.styles';
 
 export const WorkflowsList: React.FC = () => {
   const navigate = useNavigate();
@@ -214,7 +217,12 @@ export const WorkflowsList: React.FC = () => {
 
   return (
     <PageWrapper
-      title="Workfloow Templates"
+      title={
+        <TitleContainer>
+          Workfloow Templates
+          <TollTip message={TOOLTIP_MESSAGES.WORKFLOW_TEMPLATES} />
+        </TitleContainer>
+      }
       description="Create and manage reusable workfloow templates for your jobs."
       actions={[
         {


### PR DESCRIPTION
- Created a globally reusable `TollTip` wrapper around Material UI.
- Centralized tooltip text into dedicated `ToolTipConst.ts` files for maintainability.
- Integrated informative tooltips into financial summary labels (Job Estimates & Company Dashboard).
- Added tooltips to the page headers in TemplatesList and WorkflowsList.
- Refactored CompanyPage, TemplatesList, and WorkflowsList to completely eliminate inline `sx` objects in favor of dedicated styled component files.