### PR TITLE
feat(jobs): add faceted filter panel with narrow search

### DIFF
--- a/src/components/UI/PageWrapper/PageWrapper.tsx
+++ b/src/components/UI/PageWrapper/PageWrapper.tsx
@@ -6,8 +6,6 @@ import type { PageWrapperProps } from './PageWrapper.types';
 import * as S from './PageWrapper.styles';
 import FilterIcon from './Icons/FilterIcon.tsx';
 
-
-
 const PageWrapperContent = memo(
   ({
     title,
@@ -27,70 +25,68 @@ const PageWrapperContent = memo(
     headerExtra,
     maxWidth,
   }: PageWrapperProps) => {
-    const handleDropdownChange = useCallback((value: string | number | null) => {
-      if (value !== null) {
-        onDropdownChange?.(value);
-      }
-    }, [onDropdownChange]);
+    const handleDropdownChange = useCallback(
+      (value: string | number | null) => {
+        if (value !== null) {
+          onDropdownChange?.(value);
+        }
+      },
+      [onDropdownChange]
+    );
 
     return (
       <S.PageContainer maxWidth={maxWidth}>
-          <S.PageHeader>
-            <S.HeaderContent>
-              <S.HeaderLeft>
-                <S.Title>{title}</S.Title>
-                {description && <S.Description>{description}</S.Description>}
-              </S.HeaderLeft>
+        <S.PageHeader>
+          <S.HeaderContent>
+            <S.HeaderLeft>
+              <S.Title>{title}</S.Title>
+              {description && <S.Description>{description}</S.Description>}
+            </S.HeaderLeft>
 
-              <S.HeaderRight>
-                {actions.map((action) => (
-                  <Button
-                    key={action.label}
-                    onClick={action.onClick}
-                    variant={action.variant || 'contained'}
-                    color={action.color || 'primary'}
-                    disabled={action.disabled}
-                    startIcon={action.icon}
-                  >
-                    {action.label}
-                  </Button>
-                ))}
+            <S.HeaderRight>
+              {actions.map((action) => (
+                <Button
+                  key={action.label}
+                  onClick={action.onClick}
+                  variant={action.variant || 'contained'}
+                  color={action.color || 'primary'}
+                  disabled={action.disabled}
+                  startIcon={action.icon}
+                  size="small"
+                >
+                  {action.label}
+                </Button>
+              ))}
 
-                {headerExtra}
+              {headerExtra}
 
-                {dropdownOptions && dropdownOptions.length > 0 && (
-                  <S.DropdownWrapper>
-                    <StandaloneDropdown
-                      name="pageDropdown"
-                      placeHolder={dropdownPlaceholder}
-                      preFetchedOptions={dropdownOptions}
-                      defaultValue={dropdownValue || ''}
-                      onChange={handleDropdownChange}
-                      hideErrorMessage
-                      size="medium"
-                    />
-                  </S.DropdownWrapper>
-                )}
-
-                {showSearch && (
-                  <Search
-                    placeholder={searchPlaceholder}
-                    onChange={onSearchChange}
-                    onSearch={onSearch}
+              {dropdownOptions && dropdownOptions.length > 0 && (
+                <S.DropdownWrapper>
+                  <StandaloneDropdown
+                    name="pageDropdown"
+                    placeHolder={dropdownPlaceholder}
+                    preFetchedOptions={dropdownOptions}
+                    defaultValue={dropdownValue || ''}
+                    onChange={handleDropdownChange}
+                    hideErrorMessage
+                    size="medium"
                   />
-                )}
+                </S.DropdownWrapper>
+              )}
 
-                {showFilter && onFilterClick && (
-                  <S.FilterButton onClick={onFilterClick}>
-                    <FilterIcon />
-                  </S.FilterButton>
-                )}
-              </S.HeaderRight>
-            </S.HeaderContent>
-          </S.PageHeader>
+              {showSearch && <Search placeholder={searchPlaceholder} onChange={onSearchChange} onSearch={onSearch} />}
 
-          <S.PageContent>{children}</S.PageContent>
-        </S.PageContainer>
+              {showFilter && onFilterClick && (
+                <S.FilterButton onClick={onFilterClick}>
+                  <FilterIcon />
+                </S.FilterButton>
+              )}
+            </S.HeaderRight>
+          </S.HeaderContent>
+        </S.PageHeader>
+
+        <S.PageContent>{children}</S.PageContent>
+      </S.PageContainer>
     );
   }
 );

--- a/src/components/UI/Search/Search.styles.ts
+++ b/src/components/UI/Search/Search.styles.ts
@@ -1,13 +1,22 @@
 import { styled, Box } from '@mui/material';
+import { rem } from '../Typography/utility';
+import type { SearchSize } from './Search.types';
 
 interface SearchContainerProps {
   width?: string | number;
+  $size?: SearchSize;
 }
 
+const sizeWidths: Record<SearchSize, string> = {
+  small: rem(240),
+  medium: rem(300),
+  large: rem(360),
+};
+
 export const SearchContainer = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'width',
-})<SearchContainerProps>(({ width }) => ({
-  width: width || 300,
+  shouldForwardProp: (prop) => prop !== 'width' && prop !== '$size',
+})<SearchContainerProps>(({ width, $size }) => ({
+  width: width || ($size ? sizeWidths[$size] : rem(300)),
 }));
 
 export const SearchIcon = styled('svg')(() => ({

--- a/src/components/UI/Search/Search.tsx
+++ b/src/components/UI/Search/Search.tsx
@@ -1,8 +1,15 @@
 import { memo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Input } from '../Forms/Input';
-import type { SearchProps } from './Search.types';
+import type { SearchProps, SearchSize } from './Search.types';
 import * as S from './Search.styles';
+import { rem } from '../Typography/utility';
+
+const INPUT_HEIGHTS: Record<SearchSize, string> = {
+  small: rem(36),
+  medium: rem(44),
+  large: rem(48),
+};
 
 const SearchIconSvg = ({ isFocused }: { isFocused: boolean }) => (
   <S.SearchIcon
@@ -30,6 +37,7 @@ export const Search = memo(
     onChange,
     onSearch,
     disabled = false,
+    size = 'medium',
     width,
     className,
     styles,
@@ -62,9 +70,17 @@ export const Search = memo(
       setIsFocused(false);
     };
 
+    const inputStyles = {
+      ...styles,
+      input: {
+        height: INPUT_HEIGHTS[size],
+        ...styles?.input,
+      },
+    };
+
     return (
       <FormProvider {...methods}>
-        <S.SearchContainer width={width} className={className}>
+        <S.SearchContainer width={width} $size={size} className={className}>
           <Input
             name="search"
             placeholder={placeholder}
@@ -76,7 +92,7 @@ export const Search = memo(
             onKeyDown={handleKeyDown}
             onFocus={handleFocus}
             onBlur={handleBlur}
-            styles={styles}
+            styles={inputStyles}
           />
         </S.SearchContainer>
       </FormProvider>

--- a/src/components/UI/Search/Search.types.ts
+++ b/src/components/UI/Search/Search.types.ts
@@ -1,9 +1,12 @@
+export type SearchSize = 'small' | 'medium' | 'large';
+
 export interface SearchProps {
   placeholder?: string;
   value?: string;
   onChange?: (value: string) => void;
   onSearch?: (value: string) => void;
   disabled?: boolean;
+  size?: SearchSize;
   width?: string | number;
   className?: string;
   styles?: {

--- a/src/enums/JobStatus.ts
+++ b/src/enums/JobStatus.ts
@@ -1,10 +1,9 @@
-import { JobCreateRequestStatusEnum } from "../../workflow-api";
-
+import { JobCreateRequestStatusEnum } from '../../workflow-api';
 
 export const JOB_STATUS_OPTIONS = [
   { label: 'New', value: JobCreateRequestStatusEnum.New },
-    { label: 'Pending', value: JobCreateRequestStatusEnum.Pending },
-    { label: 'In Progress', value: JobCreateRequestStatusEnum.InProgress },
-    { label: 'Completed', value: JobCreateRequestStatusEnum.Completed },
-    { label: 'Cancelled', value: JobCreateRequestStatusEnum.Cancelled },
+  { label: 'Pending', value: JobCreateRequestStatusEnum.Pending },
+  { label: 'In Progress', value: JobCreateRequestStatusEnum.InProgress },
+  { label: 'Completed', value: JobCreateRequestStatusEnum.Completed },
+  { label: 'Cancelled', value: JobCreateRequestStatusEnum.Cancelled },
 ];

--- a/src/pages/jobs/components/JobsList/DataColumn.tsx
+++ b/src/pages/jobs/components/JobsList/DataColumn.tsx
@@ -7,15 +7,13 @@ const getStatusColor = (status: string): 'default' | 'primary' | 'secondary' | '
   switch (normalizedStatus) {
     case 'COMPLETED':
       return 'success';
-    case 'STARTED':
-    case 'ONGOING':
+    case 'IN_PROGRESS':
       return 'primary';
     case 'PENDING':
-    case 'INITIATED':
       return 'warning';
-    case 'SKIPPED':
+    case 'CANCELLED':
       return 'error';
-    case 'NOT_STARTED':
+    case 'NEW':
     default:
       return 'default';
   }

--- a/src/pages/jobs/components/JobsList/JobFilterPanel.styles.ts
+++ b/src/pages/jobs/components/JobsList/JobFilterPanel.styles.ts
@@ -1,0 +1,113 @@
+import { styled } from '@mui/material/styles';
+import {
+  Box,
+  Popover,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import { TuneRounded } from '@mui/icons-material';
+import { rem } from '../../../../components/UI/Typography/utility';
+
+// ─── Filter panel ────────────────────────────────────────────────────────────
+
+export const FilterPopover = styled(Popover)(({ theme }) => ({
+  '& .MuiPaper-root': {
+    marginTop: rem(4),
+    boxShadow: theme.shadows[4],
+    borderRadius: rem(8),
+  },
+}));
+
+export const PanelContainer = styled(Box)({
+  width: rem(300),
+});
+
+export const PanelHeader = styled(Box)({
+  padding: `${rem(16)} ${rem(20)} ${rem(12)}`,
+});
+
+export const PanelTitle = styled(Typography)({
+  fontWeight: 600,
+}) as typeof Typography;
+
+export const PanelBody = styled(Box)({
+  padding: `${rem(16)} ${rem(20)}`,
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: rem(20),
+});
+
+export const ViewToggleGroup = styled(ToggleButtonGroup)({
+  '& .MuiToggleButton-root': {
+    textTransform: 'none',
+    fontWeight: 500,
+    fontSize: rem(13),
+    flex: 1,
+  },
+});
+
+export const FilterSection = styled(Box, {
+  shouldForwardProp: (prop) => prop !== '$disabled',
+})<{ $disabled: boolean }>(({ $disabled }) => ({
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: rem(16),
+  opacity: $disabled ? 0.4 : 1,
+  pointerEvents: $disabled ? 'none' : 'auto',
+  transition: 'opacity 0.15s ease',
+}));
+
+export const PanelFooter = styled(Box)({
+  padding: `${rem(12)} ${rem(20)}`,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: rem(8),
+});
+
+
+export const FilterRowWrapper = styled(Box)({});
+
+export const FilterLabel = styled(Typography)({
+  display: 'block',
+  fontWeight: 500,
+  letterSpacing: rem(0.32),
+  textTransform: 'uppercase' as const,
+  fontSize: rem(11),
+  marginBottom: rem(6),
+}) as typeof Typography;
+
+// ─── JobsList header controls ─────────────────────────────────────────────────
+
+export const HeaderControls = styled(Box)({
+  display: 'flex',
+  gap: rem(8),
+  alignItems: 'center',
+});
+
+export const FilterButtonWrapper = styled(Box)({
+  position: 'relative',
+  display: 'inline-flex',
+});
+
+export const FilterCountBadge = styled(Box)({
+  position: 'absolute',
+  top: rem(-8),
+  right: rem(-8),
+  zIndex: 1,
+  pointerEvents: 'none',
+});
+
+export const FilterTuneIcon = styled(TuneRounded)({
+  fontSize: rem(18),
+});
+
+// ─── Active filter chips row ──────────────────────────────────────────────────
+
+export const ChipsRow = styled(Box)({
+  display: 'flex',
+  flexWrap: 'wrap' as const,
+  gap: rem(6),
+  marginBottom: rem(16),
+  alignItems: 'center',
+});

--- a/src/pages/jobs/components/JobsList/JobFilterPanel.tsx
+++ b/src/pages/jobs/components/JobsList/JobFilterPanel.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useEffect } from 'react';
+import { Divider, ToggleButton } from '@mui/material';
+import { StandaloneDropdown } from '../../../../components/UI/Forms/Dropdown';
+import type { DropdownOption } from '../../../../components/UI/Forms/Dropdown';
+import type { JobFilters } from '../../../../services/api';
+import { Button } from '../../../../components/UI/Button';
+import {
+  FilterPopover,
+  PanelContainer,
+  PanelHeader,
+  PanelTitle,
+  PanelBody,
+  ViewToggleGroup,
+  FilterSection,
+  PanelFooter,
+  FilterRowWrapper,
+  FilterLabel,
+} from './JobFilterPanel.styles';
+
+const STATUS_OPTIONS: DropdownOption[] = [
+  { label: 'New', value: 'NEW' },
+  { label: 'Pending', value: 'PENDING' },
+  { label: 'In Progress', value: 'IN_PROGRESS' },
+  { label: 'Completed', value: 'COMPLETED' },
+  { label: 'Cancelled', value: 'CANCELLED' },
+];
+
+// StandaloneDropdown initialises its internal state from defaultValue on mount.
+// We pass a full DropdownOption object (cast to string to satisfy the typed prop) so
+// MUI Autocomplete can resolve getOptionLabel and isOptionEqualToValue correctly.
+const toOption = (options: DropdownOption[], value?: string): DropdownOption | '' =>
+  (value ? options.find((o) => o.value === value) : undefined) ?? '';
+
+interface JobFilterPanelProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  showArchived: boolean;
+  onToggleArchived: (archived: boolean) => void;
+  currentFilters: JobFilters;
+  onApply: (filters: JobFilters) => void;
+  templateOptions: DropdownOption[];
+  customerOptions: DropdownOption[];
+  clientOptions: DropdownOption[];
+  workflowOptions: DropdownOption[];
+}
+
+export const JobFilterPanel: React.FC<JobFilterPanelProps> = ({
+  anchorEl,
+  onClose,
+  showArchived,
+  onToggleArchived,
+  currentFilters,
+  onApply,
+  templateOptions,
+  customerOptions,
+  clientOptions,
+  workflowOptions,
+}) => {
+  const [draft, setDraft] = useState<JobFilters>(currentFilters);
+  // Incremented only when we want to force-remount the dropdowns (panel open /
+  // reset / view toggle) — NOT on every selection, which was causing the remount
+  // that wiped the visual selection immediately after the user picked an option.
+  const [dropdownKey, setDropdownKey] = useState(0);
+
+  useEffect(() => {
+    if (anchorEl) {
+      setDraft(currentFilters);
+      setDropdownKey((k) => k + 1);
+    }
+  }, [anchorEl]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const set = (key: keyof JobFilters) => (v: string | number) =>
+    setDraft((prev) => ({ ...prev, [key]: (v as string) || undefined }));
+
+  const handleViewToggle = (_: React.MouseEvent, value: 'active' | 'archived' | null) => {
+    if (!value) return;
+    const archived = value === 'archived';
+    if (archived) {
+      setDraft({});
+      setDropdownKey((k) => k + 1);
+      onApply({});
+    }
+    onToggleArchived(archived);
+  };
+
+  const handleApply = () => {
+    const cleaned = Object.fromEntries(
+      Object.entries(draft).filter(([, v]) => v !== undefined && v !== '' && v !== null)
+    ) as JobFilters;
+    onApply(cleaned);
+    onClose();
+  };
+
+  const handleClear = () => {
+    setDraft({});
+    setDropdownKey((k) => k + 1);
+    onApply({});
+    onToggleArchived(false);
+    onClose();
+  };
+
+  return (
+    <FilterPopover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+    >
+      <PanelContainer>
+        <PanelHeader>
+          <PanelTitle variant="subtitle2">View & Filter</PanelTitle>
+        </PanelHeader>
+
+        <Divider />
+
+        <PanelBody>
+          <FilterRow label="View">
+            <ViewToggleGroup
+              value={showArchived ? 'archived' : 'active'}
+              exclusive
+              onChange={handleViewToggle}
+              size="small"
+              fullWidth
+            >
+              <ToggleButton value="active">Active</ToggleButton>
+              <ToggleButton value="archived">Archived</ToggleButton>
+            </ViewToggleGroup>
+          </FilterRow>
+
+          <FilterSection $disabled={showArchived}>
+            <FilterRow label="Status">
+              <StandaloneDropdown
+                key={`status-${dropdownKey}`}
+                name="filter-status"
+                placeHolder="Any status"
+                preFetchedOptions={STATUS_OPTIONS}
+                defaultValue={toOption(STATUS_OPTIONS, draft.status) as unknown as string}
+                onChange={set('status')}
+                hideErrorMessage
+                fullWidth
+              />
+            </FilterRow>
+
+            {templateOptions.length > 0 && (
+              <FilterRow label="Template">
+                <StandaloneDropdown
+                  key={`template-${dropdownKey}`}
+                  name="filter-template"
+                  placeHolder="Any template"
+                  preFetchedOptions={templateOptions}
+                  defaultValue={toOption(templateOptions, draft.templateName) as unknown as string}
+                  onChange={set('templateName')}
+                  hideErrorMessage
+                  fullWidth
+                />
+              </FilterRow>
+            )}
+
+            {customerOptions.length > 0 && (
+              <FilterRow label="Customer">
+                <StandaloneDropdown
+                  key={`customer-${dropdownKey}`}
+                  name="filter-customer"
+                  placeHolder="Any customer"
+                  preFetchedOptions={customerOptions}
+                  defaultValue={toOption(customerOptions, draft.customerName) as unknown as string}
+                  onChange={set('customerName')}
+                  hideErrorMessage
+                  fullWidth
+                />
+              </FilterRow>
+            )}
+
+            {clientOptions.length > 0 && (
+              <FilterRow label="Client">
+                <StandaloneDropdown
+                  key={`client-${dropdownKey}`}
+                  name="filter-client"
+                  placeHolder="Any client"
+                  preFetchedOptions={clientOptions}
+                  defaultValue={toOption(clientOptions, draft.clientName) as unknown as string}
+                  onChange={set('clientName')}
+                  hideErrorMessage
+                  fullWidth
+                />
+              </FilterRow>
+            )}
+
+            {workflowOptions.length > 0 && (
+              <FilterRow label="Workflow">
+                <StandaloneDropdown
+                  key={`workflow-${dropdownKey}`}
+                  name="filter-workflow"
+                  placeHolder="Any workflow"
+                  preFetchedOptions={workflowOptions}
+                  defaultValue={toOption(workflowOptions, draft.workflowName) as unknown as string}
+                  onChange={set('workflowName')}
+                  hideErrorMessage
+                  fullWidth
+                />
+              </FilterRow>
+            )}
+          </FilterSection>
+        </PanelBody>
+
+        <Divider />
+
+        <PanelFooter>
+          <Button variant="outlined" color="secondary" size="small" onClick={handleClear}>
+            Reset all
+          </Button>
+          <Button variant="contained" color="primary" size="small" onClick={handleApply} disabled={showArchived}>
+            Apply filters
+          </Button>
+        </PanelFooter>
+      </PanelContainer>
+    </FilterPopover>
+  );
+};
+
+const FilterRow: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <FilterRowWrapper>
+    <FilterLabel variant="caption" color="text.secondary">
+      {label}
+    </FilterLabel>
+    {children}
+  </FilterRowWrapper>
+);

--- a/src/pages/jobs/components/JobsList/JobsList.styles.ts
+++ b/src/pages/jobs/components/JobsList/JobsList.styles.ts
@@ -1,8 +1,20 @@
 import { Chip, styled } from '@mui/material';
+import { rem } from '../../../../components/UI/Typography/utility';
 
 export const StatusChip = styled(Chip)(() => ({
   fontWeight: 600,
-  fontSize: '0.75rem',
-  height: 24,
-  letterSpacing: '0.5px',
+  fontSize: rem(12),
+  height: rem(24),
+  letterSpacing: rem(0.5),
 }));
+
+export const FilterChip = styled(Chip)({
+  borderRadius: rem(6),
+  fontSize: rem(12),
+});
+
+export const ClearAllChip = styled(Chip)({
+  borderRadius: rem(6),
+  fontSize: rem(12),
+  cursor: 'pointer',
+});

--- a/src/pages/jobs/components/JobsList/JobsList.tsx
+++ b/src/pages/jobs/components/JobsList/JobsList.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box } from '@mui/material';
 import { PageWrapper } from '../../../../components/UI/PageWrapper';
-import { StandaloneDropdown } from '../../../../components/UI/Forms/Dropdown';
+import { Search } from '../../../../components/UI/Search';
 import Table from '../../../../components/UI/Table/Table';
 import type { ITableAction } from '../../../../components/UI/Table/ITable';
 import { useGlobalModalOuterContext, ModalSizes, ConfirmationModal } from '../../../../components/UI/GlobalModal';
@@ -16,33 +15,48 @@ import {
 } from '../../../../services/api';
 import type {
   JobResponse,
-  JobTemplateResponse,
   JobTemplateFieldResponse,
   AssetResponse,
   PagedModelAssetResponse,
   CustomerResponse,
   ClientResponse,
   WorkflowResponse,
+  JobFilters,
 } from '../../../../services/api';
 import { useSnackbar } from '../../../../contexts/SnackbarContext';
 import { extractErrorMessage } from '../../../../utils/errorHandler';
 import { generateJobColumns, type JobTableRow } from './DataColumn';
 import { AddJobWizard } from '../AddJobWizard';
 import { useFetch } from '../../../../hooks';
+import { JobFilterPanel } from './JobFilterPanel';
+import { FilterChip, ClearAllChip } from './JobsList.styles';
+import { HeaderControls, FilterButtonWrapper, FilterCountBadge, FilterTuneIcon, ChipsRow } from './JobFilterPanel.styles';
+import { IconButton } from '../../../../components/UI/Button';
+import { Badge } from '../../../../components/UI/Badge';
+import { JOB_STATUS_OPTIONS } from '../../../../enums';
 
 export const JobsList: React.FC = () => {
   const navigate = useNavigate();
-  const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null);
   const [showArchived, setShowArchived] = useState(false);
   const [hasShownNoTemplateModal, setHasShownNoTemplateModal] = useState(false);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchKey, setSearchKey] = useState(0);
+  const [filters, setFilters] = useState<JobFilters>({});
+  const [filterAnchorEl, setFilterAnchorEl] = useState<HTMLElement | null>(null);
+
   const { setGlobalModalOuterProps, resetGlobalModalOuterProps } = useGlobalModalOuterContext();
   const { showSuccess, showError } = useSnackbar();
 
-  const { data: templatesData, loading: loadingTemplates } = useFetch<JobTemplateResponse[]>(
-    () => jobTemplateService.getAllTemplates(),
-    [],
-    { onError: () => showError('Failed to load templates') }
-  );
+  // Debounce search input → searchQuery (triggers API refetch)
+  useEffect(() => {
+    const t = setTimeout(() => setSearchQuery(searchInput), 400);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  const { data: templatesData, loading: loadingTemplates } = useFetch(() => jobTemplateService.getAllTemplates(), [], {
+    onError: () => showError('Failed to load templates'),
+  });
   const templates = useMemo(() => templatesData ?? [], [templatesData]);
 
   const { data: assetsPage } = useFetch<PagedModelAssetResponse>(() => assetService.getAllAssets(0, 1000), [], {
@@ -65,28 +79,35 @@ export const JobsList: React.FC = () => {
   });
   const workflows = useMemo<WorkflowResponse[]>(() => workflowsData ?? [], [workflowsData]);
 
+  // Resolve template ID from active template name filter (drives dynamic columns)
+  const filteredTemplateId = useMemo(
+    () => (filters.templateName ? (templates.find((t) => t.name === filters.templateName)?.id ?? null) : null),
+    [filters.templateName, templates]
+  );
+
   const { data: templateFieldsData } = useFetch<JobTemplateFieldResponse[]>(
-    () => jobTemplateService.getTemplateFields(selectedTemplateId!),
-    [selectedTemplateId],
+    () => jobTemplateService.getTemplateFields(filteredTemplateId!),
+    [filteredTemplateId],
     {
-      skip: !selectedTemplateId,
+      skip: !filteredTemplateId,
       onError: (error) => showError(extractErrorMessage(error, 'Failed to load template fields')),
     }
   );
   const templateFields = useMemo(() => templateFieldsData ?? [], [templateFieldsData]);
+
+  // Stable filter object passed to getAllJobs — only changes when filters or searchQuery change
+  const apiFilters = useMemo<JobFilters>(
+    () => ({ ...filters, search: searchQuery || undefined }),
+    [filters, searchQuery]
+  );
 
   const {
     data: rawJobs,
     loading,
     refetch: fetchJobs,
   } = useFetch<JobResponse[]>(
-    () =>
-      showArchived
-        ? jobService.getArchivedJobs()
-        : selectedTemplateId
-          ? jobService.getJobsByTemplate(selectedTemplateId)
-          : jobService.getAllJobs(),
-    [selectedTemplateId, showArchived],
+    () => (showArchived ? jobService.getArchivedJobs() : jobService.getAllJobs(apiFilters)),
+    [showArchived, apiFilters],
     {
       skip: loadingTemplates,
       onError: (error) => showError(extractErrorMessage(error, 'Failed to load jobs')),
@@ -139,7 +160,7 @@ export const JobsList: React.FC = () => {
     });
   }, [rawJobs, assets, templates, customers, clients, workflows]);
 
-  // Show "No Templates Available" modal once on load if no templates exist
+  // No-template modal on first load
   useEffect(() => {
     if (!loadingTemplates && templates.length === 0 && !hasShownNoTemplateModal) {
       setHasShownNoTemplateModal(true);
@@ -197,7 +218,6 @@ export const JobsList: React.FC = () => {
       });
       return;
     }
-
     setGlobalModalOuterProps({
       isOpen: true,
       size: ModalSizes.LARGE,
@@ -256,7 +276,6 @@ export const JobsList: React.FC = () => {
                 resetGlobalModalOuterProps();
                 fetchJobs();
               } catch (error) {
-                console.error('Error deleting job:', error);
                 showError(extractErrorMessage(error, 'Failed to delete job'));
                 resetGlobalModalOuterProps();
               }
@@ -279,7 +298,7 @@ export const JobsList: React.FC = () => {
           <ConfirmationModal
             title="Archive Job"
             message={`Are you sure you want to archive Job #${job.id}?`}
-            description="Archived jobs are removed from the active list. This action can be reviewed by your administrator."
+            description="Archived jobs are removed from the active list."
             variant="default"
             confirmButtonText="Archive"
             cancelButtonText="Cancel"
@@ -290,7 +309,6 @@ export const JobsList: React.FC = () => {
                 resetGlobalModalOuterProps();
                 fetchJobs();
               } catch (error) {
-                console.error('Error archiving job:', error);
                 showError(extractErrorMessage(error, 'Failed to archive job'));
                 resetGlobalModalOuterProps();
               }
@@ -315,46 +333,166 @@ export const JobsList: React.FC = () => {
 
   const columns = useMemo(() => generateJobColumns(templateFields), [templateFields]);
 
+  // Dropdown options for the filter panel (value = name, since API takes name strings)
   const templateOptions = useMemo(
-    () => templates.map((t) => ({ label: t.name || '', value: t.id?.toString() || '' })),
+    () => templates.map((t) => ({ label: t.name || '', value: t.name || '' })),
     [templates]
   );
+  const customerOptions = useMemo(
+    () => customers.map((c) => ({ label: c.name || '', value: c.name || '' })),
+    [customers]
+  );
+  const clientOptions = useMemo(() => clients.map((c) => ({ label: c.name || '', value: c.name || '' })), [clients]);
+  const workflowOptions = useMemo(
+    () => workflows.map((w) => ({ label: w.name || '', value: w.name || '' })),
+    [workflows]
+  );
 
-  const archivedFilterOptions = [
-    { label: 'Active Jobs', value: 'active' },
-    { label: 'Archived Jobs', value: 'archived' },
-  ];
+  // Active filter chips — archived chip shown instead of filter chips when in archived mode
+  const activeChips = useMemo(() => {
+    const chips: { key: string; label: string; onDelete: () => void }[] = [];
+
+    if (searchQuery) {
+      chips.push({
+        key: 'search',
+        label: `"${searchQuery}"`,
+        onDelete: () => {
+          setSearchInput('');
+          setSearchQuery('');
+          setSearchKey((k) => k + 1);
+        },
+      });
+    }
+
+    if (showArchived) {
+      chips.push({
+        key: 'archived',
+        label: 'Archived jobs',
+        onDelete: () => setShowArchived(false),
+      });
+      return chips;
+    }
+
+    if (filters.status) {
+      chips.push({
+        key: 'status',
+        label: `Status: ${JOB_STATUS_OPTIONS.find((o) => o.value === filters.status)?.label ?? filters.status}`,
+        onDelete: () =>
+          setFilters((prev) => {
+            const next = { ...prev };
+            delete next.status;
+            return next;
+          }),
+      });
+    }
+    if (filters.templateName) {
+      chips.push({
+        key: 'templateName',
+        label: `Template: ${filters.templateName}`,
+        onDelete: () =>
+          setFilters((prev) => {
+            const next = { ...prev };
+            delete next.templateName;
+            return next;
+          }),
+      });
+    }
+    if (filters.customerName) {
+      chips.push({
+        key: 'customerName',
+        label: `Customer: ${filters.customerName}`,
+        onDelete: () =>
+          setFilters((prev) => {
+            const next = { ...prev };
+            delete next.customerName;
+            return next;
+          }),
+      });
+    }
+    if (filters.clientName) {
+      chips.push({
+        key: 'clientName',
+        label: `Client: ${filters.clientName}`,
+        onDelete: () =>
+          setFilters((prev) => {
+            const next = { ...prev };
+            delete next.clientName;
+            return next;
+          }),
+      });
+    }
+    if (filters.workflowName) {
+      chips.push({
+        key: 'workflowName',
+        label: `Workflow: ${filters.workflowName}`,
+        onDelete: () =>
+          setFilters((prev) => {
+            const next = { ...prev };
+            delete next.workflowName;
+            return next;
+          }),
+      });
+    }
+    return chips;
+  }, [filters, searchQuery, showArchived]);
+
+  const clearAllFilters = useCallback(() => {
+    setFilters({});
+    setShowArchived(false);
+    setSearchInput('');
+    setSearchQuery('');
+    setSearchKey((k) => k + 1);
+  }, []);
+
+  // Badge count: one per active filter dimension + 1 if archived
+  const activeBadgeCount = Object.keys(filters).length + (showArchived ? 1 : 0);
+  const hasActiveFilters = activeBadgeCount > 0;
 
   return (
     <PageWrapper
       title="All Jobs"
       description="Manage jobs, assign workers, and track progress."
-      actions={[
-        {
-          label: 'Create Job',
-          onClick: handleAddJob,
-          variant: 'contained',
-          color: 'primary',
-        },
-      ]}
+      actions={[{ label: 'Create Job', onClick: handleAddJob, variant: 'contained', color: 'primary' }]}
       headerExtra={
-        <Box sx={{ minWidth: 160, display: 'flex', alignItems: 'center' }}>
-          <StandaloneDropdown
-            name="archivedFilter"
-            placeHolder="Active Jobs"
-            preFetchedOptions={archivedFilterOptions}
-            defaultValue={showArchived ? 'archived' : 'active'}
-            onChange={(value) => setShowArchived(value === 'archived')}
-            hideErrorMessage
-            size="medium"
+        <HeaderControls>
+          <Search
+            key={searchKey}
+            placeholder="Search jobs..."
+            onChange={setSearchInput}
+            onSearch={(v) => {
+              setSearchInput(v);
+              setSearchQuery(v);
+            }}
+            size="small"
           />
-        </Box>
+          <FilterButtonWrapper>
+            <IconButton
+              variant="outlined"
+              color={hasActiveFilters ? 'primary' : 'secondary'}
+              size="small"
+              onClick={(e) => setFilterAnchorEl(e.currentTarget)}
+              aria-label="Open filters"
+            >
+              <FilterTuneIcon />
+            </IconButton>
+            {hasActiveFilters && (
+              <FilterCountBadge>
+                <Badge variant="primary" size="small">{activeBadgeCount}</Badge>
+              </FilterCountBadge>
+            )}
+          </FilterButtonWrapper>
+        </HeaderControls>
       }
-      dropdownOptions={!showArchived ? templateOptions : []}
-      dropdownValue={selectedTemplateId?.toString()}
-      dropdownPlaceholder="All Jobs (No Template Filter)"
-      onDropdownChange={(value) => setSelectedTemplateId(value ? Number(value) : null)}
     >
+      {activeChips.length > 0 && (
+        <ChipsRow>
+          {activeChips.map((chip) => (
+            <FilterChip key={chip.key} label={chip.label} onDelete={chip.onDelete} size="small" variant="outlined" />
+          ))}
+          {activeChips.length > 1 && <ClearAllChip label="Clear all" size="small" onClick={clearAllFilters} />}
+        </ChipsRow>
+      )}
+
       <Table<JobTableRow>
         columns={columns}
         data={jobs}
@@ -367,13 +505,26 @@ export const JobsList: React.FC = () => {
         emptyMessage={
           showArchived
             ? 'No archived jobs found.'
-            : selectedTemplateId
-              ? 'No jobs found for this template. Add your first job to get started.'
+            : activeChips.length > 0
+              ? 'No jobs match the current filters.'
               : 'No jobs found. Add your first job to get started.'
         }
         rowsPerPage={100}
         showPagination={true}
         enableStickyLeft={true}
+      />
+
+      <JobFilterPanel
+        anchorEl={filterAnchorEl}
+        onClose={() => setFilterAnchorEl(null)}
+        showArchived={showArchived}
+        onToggleArchived={setShowArchived}
+        currentFilters={filters}
+        onApply={setFilters}
+        templateOptions={templateOptions}
+        customerOptions={customerOptions}
+        clientOptions={clientOptions}
+        workflowOptions={workflowOptions}
       />
     </PageWrapper>
   );

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -36,7 +36,7 @@ export type { JobTemplateResponse, JobTemplateCreateRequest, JobTemplateFieldRes
 export { JobTemplateFieldCreateRequestJobFieldTypeEnum } from '../../../workflow-api';
 
 export { jobService } from './job';
-export type { JobResponse, JobCreateRequest, JobUpdateRequest } from './job';
+export type { JobResponse, JobCreateRequest, JobUpdateRequest, JobFilters } from './job';
 
 export { assetService } from './asset';
 export type {

--- a/src/services/api/job.ts
+++ b/src/services/api/job.ts
@@ -3,11 +3,22 @@ import type {
   JobResponse,
   JobCreateRequest,
   JobUpdateRequest,
+  PagedModelJobResponse,
+  JobGetAllStatusEnum,
 } from '../../../workflow-api';
 import { env } from '../../config/env';
 import { axiosInstance } from './axiosConfig';
 
 export type { JobResponse, JobCreateRequest, JobUpdateRequest };
+
+export interface JobFilters {
+  search?: string;
+  templateName?: string;
+  customerName?: string;
+  clientName?: string;
+  workflowName?: string;
+  status?: string;
+}
 
 function getJobApi(): JobsApi {
   const config = new Configuration({ basePath: env.apiBaseUrl });
@@ -15,10 +26,18 @@ function getJobApi(): JobsApi {
 }
 
 export const jobService = {
-  async getAllJobs(): Promise<{ data: JobResponse[] }> {
-    const res = await getJobApi().jobGetAll({ page: 0, size: 1000, sort: ['createdAt,desc'] });
-    // Generated type says PagedModelJobResponse but the API returns Array<JobResponse> at runtime
-    return { ...res, data: res.data as unknown as JobResponse[] };
+  async getAllJobs(filters?: JobFilters): Promise<{ data: JobResponse[] }> {
+    const res = await getJobApi().jobGetAll(
+      { page: 0, size: 1000, sort: ['createdAt,desc'] },
+      filters?.search || undefined,
+      filters?.customerName || undefined,
+      filters?.clientName || undefined,
+      filters?.workflowName || undefined,
+      filters?.templateName || undefined,
+      filters?.status as JobGetAllStatusEnum | undefined,
+    );
+    const paged = res.data as unknown as PagedModelJobResponse;
+    return { ...res, data: paged.content ?? [] };
   },
 
   async getArchivedJobs(): Promise<{ data: JobResponse[] }> {


### PR DESCRIPTION
- Fix getAllJobs to extract paged.content from PagedModelJobResponse (was breaking with "(rawJobs ?? []).map is not a function")
- Add JobFilters interface with search/status/template/customer/ client/workflow params; pass to jobGetAll API call
- Build JobFilterPanel: Active/Archived view toggle + per-dimension StandaloneDropdown filters with dropdownKey remount strategy so selections aren't wiped mid-interaction
- Add active filter chips row with per-chip delete and "Clear all"
- Replace raw MUI styled filter button with project IconButton + Badge overlay showing active filter count
- Add size prop (small/medium/large) to Search component; use size="small" in JobsList to align with filter button height
- Move STATUS_DISPLAY to JOB_STATUS_OPTIONS lookup in enums
- Fix DataColumn status color mapping to match actual API enum values