### PR TITLE
fix(jobs): send address in update payload and extract address compone…

### DIFF
--- a/src/components/UI/GoogleMap/GoogleMap.tsx
+++ b/src/components/UI/GoogleMap/GoogleMap.tsx
@@ -47,6 +47,7 @@ import {
   getMarkerIcon,
   getGeolocationErrorMessage,
 } from './GoogleMapConst';
+import { extractAddressComponents } from './PlacesAutocompleteConst';
 import { Typography } from '@mui/material';
 
 const GoogleMap: React.FC<GoogleMapProps> = ({
@@ -192,7 +193,13 @@ const GoogleMap: React.FC<GoogleMapProps> = ({
       const geocoder = new google.maps.Geocoder();
       geocoder.geocode({ location }, (results, status) => {
         if (status === 'OK' && results?.[0]) {
-          onLocationSelect?.({ address: results[0].formatted_address, location, placeId: results[0].place_id });
+          const components = extractAddressComponents(results[0].address_components);
+          onLocationSelect?.({
+            address: results[0].formatted_address,
+            location,
+            placeId: results[0].place_id,
+            ...components,
+          });
         } else {
           onLocationSelect?.({ address: `${location.lat.toFixed(6)}, ${location.lng.toFixed(6)}`, location });
         }

--- a/src/components/UI/GoogleMap/GoogleMap.types.ts
+++ b/src/components/UI/GoogleMap/GoogleMap.types.ts
@@ -35,6 +35,10 @@ export interface PlaceDetails {
   name?: string;
   location: Location;
   placeId?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
   workerData?: WorkerMarkerData;
   jobLocationData?: JobLocationMarkerData;
   /** True when Google couldn't geocode the address — user should click map to set pin */

--- a/src/components/UI/GoogleMap/PlacesAutocomplete.tsx
+++ b/src/components/UI/GoogleMap/PlacesAutocomplete.tsx
@@ -15,6 +15,7 @@ import {
   MIN_SEARCH_LENGTH,
   PLACE_DETAIL_FIELDS,
   getNoOptionsText,
+  extractAddressComponents,
 } from './PlacesAutocompleteConst';
 
 const PlacesAutocomplete: React.FC<PlacesAutocompleteProps> = ({
@@ -146,6 +147,7 @@ const PlacesAutocomplete: React.FC<PlacesAutocompleteProps> = ({
         { placeId: option.value, fields: [...PLACE_DETAIL_FIELDS] },
         (place, status) => {
           if (status === google.maps.places.PlacesServiceStatus.OK && place?.geometry?.location) {
+            const components = extractAddressComponents(place.address_components);
             onPlaceSelect({
               name: place.name ?? '',
               address: place.formatted_address ?? '',
@@ -154,6 +156,7 @@ const PlacesAutocomplete: React.FC<PlacesAutocompleteProps> = ({
                 lng: place.geometry.location.lng(),
               },
               placeId: place.place_id,
+              ...components,
             });
           }
         }

--- a/src/components/UI/GoogleMap/PlacesAutocompleteConst.ts
+++ b/src/components/UI/GoogleMap/PlacesAutocompleteConst.ts
@@ -4,7 +4,18 @@ export const DEBOUNCE_DELAY_MS = 300;
 
 export const MIN_SEARCH_LENGTH = 2;
 
-export const PLACE_DETAIL_FIELDS = ['name', 'formatted_address', 'geometry', 'place_id'] as const;
+export const PLACE_DETAIL_FIELDS = ['name', 'formatted_address', 'geometry', 'place_id', 'address_components'] as const;
+
+export function extractAddressComponents(components: google.maps.GeocoderAddressComponent[] | undefined) {
+  const get = (type: string) =>
+    components?.find((c) => c.types.includes(type));
+  return {
+    city: get('locality')?.long_name ?? get('sublocality_level_1')?.long_name ?? '',
+    state: get('administrative_area_level_1')?.long_name ?? '',
+    postalCode: get('postal_code')?.long_name ?? '',
+    country: get('country')?.long_name ?? '',
+  };
+}
 
 export const getNoOptionsText = (inputValue: string): string => {
   return inputValue.length < MIN_SEARCH_LENGTH

--- a/src/components/UI/Table/components/DataTableBody/DataTableBody.tsx
+++ b/src/components/UI/Table/components/DataTableBody/DataTableBody.tsx
@@ -126,12 +126,6 @@ const DataTableBody: React.FC<IDataTableBody> = ({
 
   return (
     <>
-      {loading && (
-        <LoadingOverlay>
-          <Loader size={40} centered={false} />
-        </LoadingOverlay>
-      )}
-
       {paginatedRows.map((row) => (
         <StyledTableRow
           key={row.id}

--- a/src/pages/jobs/components/AddJobWizard/AddJobWizard.tsx
+++ b/src/pages/jobs/components/AddJobWizard/AddJobWizard.tsx
@@ -35,6 +35,11 @@ export interface WizardData {
   fieldValues?: { [key: string]: string | number | boolean };
   address?: {
     fullAddress: string;
+    street?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    country?: string;
     latitude?: number;
     longitude?: number;
   };
@@ -89,6 +94,11 @@ export const AddJobWizard: React.FC<AddJobWizardProps> = ({ onSuccess, jobId }) 
                 ]
                   .filter(Boolean)
                   .join(', '),
+                street: job.address.street,
+                city: job.address.city,
+                state: job.address.state,
+                postalCode: job.address.postalCode,
+                country: job.address.country,
                 latitude: job.address.latitude,
                 longitude: job.address.longitude,
               }

--- a/src/pages/jobs/components/AddJobWizard/steps/Step3AssignDetails.tsx
+++ b/src/pages/jobs/components/AddJobWizard/steps/Step3AssignDetails.tsx
@@ -212,6 +212,11 @@ export const Step3AssignDetails: React.FC<Step3Props> = ({ onStepComplete, initi
         address: selectedLocation
           ? {
               fullAddress: selectedLocation.address,
+              street: selectedLocation.address,
+              city: selectedLocation.city,
+              state: selectedLocation.state,
+              postalCode: selectedLocation.postalCode,
+              country: selectedLocation.country,
               latitude: selectedLocation.location.lat,
               longitude: selectedLocation.location.lng,
             }

--- a/src/pages/jobs/components/AddJobWizard/steps/Step4CustomFields.tsx
+++ b/src/pages/jobs/components/AddJobWizard/steps/Step4CustomFields.tsx
@@ -194,6 +194,17 @@ export const Step4CustomFields: React.FC<Step4Props> = ({ wizardData, onSuccess,
             if (wizardData.customerId) updatePayload.customerId = wizardData.customerId;
             if (wizardData.clientId) updatePayload.clientId = wizardData.clientId;
             if (wizardData.assetIds?.length) updatePayload.assetIds = wizardData.assetIds;
+            if (wizardData.address) {
+              updatePayload.address = {
+                ...(wizardData.address.street && { street: wizardData.address.street }),
+                ...(wizardData.address.city && { city: wizardData.address.city }),
+                ...(wizardData.address.state && { state: wizardData.address.state }),
+                ...(wizardData.address.postalCode && { postalCode: wizardData.address.postalCode }),
+                ...(wizardData.address.country && { country: wizardData.address.country }),
+                ...(wizardData.address.latitude != null && { latitude: wizardData.address.latitude }),
+                ...(wizardData.address.longitude != null && { longitude: wizardData.address.longitude }),
+              };
+            }
 
             await jobService.updateJob(jobId, updatePayload);
             showSuccess('Job updated successfully');
@@ -248,9 +259,13 @@ export const Step4CustomFields: React.FC<Step4Props> = ({ wizardData, onSuccess,
           }
           if (wizardData.address) {
             createPayload.address = {
-              street: wizardData.address.fullAddress,
-              latitude: wizardData.address.latitude,
-              longitude: wizardData.address.longitude,
+              ...(wizardData.address.street && { street: wizardData.address.street }),
+              ...(wizardData.address.city && { city: wizardData.address.city }),
+              ...(wizardData.address.state && { state: wizardData.address.state }),
+              ...(wizardData.address.postalCode && { postalCode: wizardData.address.postalCode }),
+              ...(wizardData.address.country && { country: wizardData.address.country }),
+              ...(wizardData.address.latitude != null && { latitude: wizardData.address.latitude }),
+              ...(wizardData.address.longitude != null && { longitude: wizardData.address.longitude }),
             };
           }
 

--- a/src/pages/jobs/components/JobFormFields/LocationMapField.styles.ts
+++ b/src/pages/jobs/components/JobFormFields/LocationMapField.styles.ts
@@ -1,0 +1,8 @@
+import { styled, Box } from '@mui/material';
+
+export const MapWrapper = styled(Box)(({ theme }) => ({
+  height: 300,
+  borderRadius: Number(theme.shape.borderRadius) * 2,
+  border: `1px solid ${theme.palette.divider}`,
+  overflow: 'hidden',
+}));

--- a/src/pages/jobs/components/JobFormFields/LocationMapField.tsx
+++ b/src/pages/jobs/components/JobFormFields/LocationMapField.tsx
@@ -1,18 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useJsApiLoader } from '@react-google-maps/api';
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import GoogleMap from '../../../../components/UI/GoogleMap/GoogleMap';
 import type { PlaceDetails } from '../../../../components/UI/GoogleMap';
 import { GOOGLE_MAPS_CONFIG, isGoogleMapsConfigured } from '../../../../config/googleMaps';
+import { MapWrapper } from './LocationMapField.styles';
 
-/**
- * LocationMapField
- * Plugs into react-hook-form via useFormContext.
- * - Edit mode: reads addressStreet, geocodes it, shows an existing pin.
- * - Create / edit: user can search and select a new location via the map.
- * - On selection, writes the formatted address back to addressStreet.
- */
 const LocationMapField: React.FC = () => {
   const { setValue, watch } = useFormContext();
   const addressStreet = watch('addressStreet') as string;
@@ -27,10 +21,8 @@ const LocationMapField: React.FC = () => {
   const [selectedLocation, setSelectedLocation] = useState<PlaceDetails | null>(null);
   const [mapCenter, setMapCenter] = useState(GOOGLE_MAPS_CONFIG.defaultCenter);
   const [mapZoom, setMapZoom] = useState(GOOGLE_MAPS_CONFIG.defaultZoom);
-  // Guard only the geocoding API call — not the coordinates restore path
   const geocodedRef = useRef(false);
 
-  // Restore pin when coordinates are available (runs whenever lat/lng/address change)
   useEffect(() => {
     if (!isLoaded) return;
 
@@ -42,7 +34,6 @@ const LocationMapField: React.FC = () => {
       return;
     }
 
-    // Fall back to geocoding only when no coordinates exist yet
     if (!addressStreet || geocodedRef.current) return;
     geocodedRef.current = true;
 
@@ -64,10 +55,10 @@ const LocationMapField: React.FC = () => {
 
   const handleLocationSelect = (place: PlaceDetails) => {
     setValue('addressStreet', place.address, { shouldDirty: true });
-    setValue('addressCity', '');
-    setValue('addressState', '');
-    setValue('addressPostalCode', '');
-    setValue('addressCountry', '');
+    setValue('addressCity', place.city ?? '', { shouldDirty: true });
+    setValue('addressState', place.state ?? '', { shouldDirty: true });
+    setValue('addressPostalCode', place.postalCode ?? '', { shouldDirty: true });
+    setValue('addressCountry', place.country ?? '', { shouldDirty: true });
 
     if (place.isManualAddressOnly) {
       setSelectedLocation(null);
@@ -92,7 +83,7 @@ const LocationMapField: React.FC = () => {
   }
 
   return (
-    <Box sx={{ height: 300, borderRadius: 2, border: '1px solid', borderColor: 'divider' }}>
+    <MapWrapper>
       <GoogleMap
         center={mapCenter}
         zoom={mapZoom}
@@ -103,7 +94,7 @@ const LocationMapField: React.FC = () => {
         searchInitialValue={addressStreet || undefined}
         height="300px"
       />
-    </Box>
+    </MapWrapper>
   );
 };
 

--- a/src/pages/jobs/components/JobsList/DataColumn.tsx
+++ b/src/pages/jobs/components/JobsList/DataColumn.tsx
@@ -2,7 +2,9 @@ import type { ITableColumn } from '../../../../components/UI/Table/ITable';
 import type { JobTemplateFieldResponse } from '../../../../services/api';
 import { StatusChip } from './JobsList.styles';
 
-const getStatusColor = (status: string): 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' => {
+const getStatusColor = (
+  status: string
+): 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' => {
   const normalizedStatus = status?.toUpperCase() || '';
   switch (normalizedStatus) {
     case 'COMPLETED':
@@ -45,7 +47,7 @@ export const generateJobColumns = (templateFields: JobTemplateFieldResponse[] = 
   const baseColumns: ITableColumn<JobTableRow>[] = [
     {
       id: 'workflowName',
-      label: 'Workflow',
+      label: 'Workfloow',
       accessor: 'workflowName',
       sortable: true,
       width: 'auto',
@@ -91,13 +93,7 @@ export const generateJobColumns = (templateFields: JobTemplateFieldResponse[] = 
       width: 'auto',
       render: (row) => {
         const statusText = row.status || 'UNKNOWN';
-        return (
-          <StatusChip
-            label={statusText.replace(/_/g, ' ')}
-            color={getStatusColor(statusText)}
-            size="small"
-          />
-        );
+        return <StatusChip label={statusText.replace(/_/g, ' ')} color={getStatusColor(statusText)} size="small" />;
       },
     },
   ];

--- a/src/pages/jobs/components/JobsList/JobsList.tsx
+++ b/src/pages/jobs/components/JobsList/JobsList.tsx
@@ -30,7 +30,13 @@ import { AddJobWizard } from '../AddJobWizard';
 import { useFetch } from '../../../../hooks';
 import { JobFilterPanel } from './JobFilterPanel';
 import { FilterChip, ClearAllChip } from './JobsList.styles';
-import { HeaderControls, FilterButtonWrapper, FilterCountBadge, FilterTuneIcon, ChipsRow } from './JobFilterPanel.styles';
+import {
+  HeaderControls,
+  FilterButtonWrapper,
+  FilterCountBadge,
+  FilterTuneIcon,
+  ChipsRow,
+} from './JobFilterPanel.styles';
 import { IconButton } from '../../../../components/UI/Button';
 import { Badge } from '../../../../components/UI/Badge';
 import { JOB_STATUS_OPTIONS } from '../../../../enums';
@@ -477,7 +483,9 @@ export const JobsList: React.FC = () => {
             </IconButton>
             {hasActiveFilters && (
               <FilterCountBadge>
-                <Badge variant="primary" size="small">{activeBadgeCount}</Badge>
+                <Badge variant="primary" size="small">
+                  {activeBadgeCount}
+                </Badge>
               </FilterCountBadge>
             )}
           </FilterButtonWrapper>


### PR DESCRIPTION
…nts from Places API

- Extend WizardData.address to include individual fields (street, city, state, postalCode, country)
- Populate individual address fields when loading an existing job in AddJobWizard
- Pass all address components from PlaceDetails in Step3 onStepComplete
- Add missing address block to Step4 update payload (was silently dropped on edit)
- Fix create payload to use individual address components instead of dumping fullAddress into street
- Add city/state/postalCode/country to PlaceDetails type
- Extract address_components from Places Autocomplete and map click geocoder results
- Remove LoadingOverlay div rendered inside tbody (invalid HTML, caused hydration error)
- Replace inline Box sx on LocationMapField with MapWrapper styled component