### PR TITLE
feat(jobs): redesign JobWorkLogsTab steps navigation and note detail …

### DIFF
--- a/src/pages/jobs/components/JobDetailsSection/JobDetailsSection.styles.ts
+++ b/src/pages/jobs/components/JobDetailsSection/JobDetailsSection.styles.ts
@@ -63,13 +63,19 @@ export const FieldValue = styled(Typography)<{ $notSet?: boolean }>(({ theme, $n
   color: $notSet ? theme.palette.text.disabled : theme.palette.text.primary,
   fontWeight: $notSet ? 400 : 500,
   flex: 1,
+  minWidth: 0,
+  wordBreak: 'break-word',
+  overflowWrap: 'break-word',
+  whiteSpace: 'pre-wrap',
   fontStyle: $notSet ? 'italic' : 'normal',
 }));
 
 export const FieldAction = styled(Box)(({ theme }) => ({
   marginLeft: 'auto',
+  flexShrink: 0,
   display: 'flex',
   alignItems: 'center',
+  paddingLeft: theme.spacing(1),
 }));
 
 export const ActionButton = styled(Button)(({ theme }) => ({
@@ -88,6 +94,7 @@ export const DividerLine = styled(Box)(({ theme }) => ({
 
 export const InlineEditContainer = styled(Box)(() => ({
   flex: 1,
+  minWidth: 0,
   display: 'flex',
   alignItems: 'center',
   gap: '0.5rem',

--- a/src/pages/jobs/components/JobDetailsSection/JobDetailsSection.tsx
+++ b/src/pages/jobs/components/JobDetailsSection/JobDetailsSection.tsx
@@ -35,6 +35,7 @@ import { AssignAssetModal } from '../../../assets/components';
 import type { PlaceDetails } from '../../../../components/UI/GoogleMap/GoogleMap.types';
 import { GOOGLE_MAPS_CONFIG } from '../../../../config/googleMaps';
 import { geocodeAddress } from '../../../../utils/mapDataHelpers';
+import { extractFieldValue } from '../../../../utils/fieldValueHelper';
 import * as S from './JobDetailsSection.styles';
 
 interface JobDetailsSectionProps {
@@ -150,22 +151,38 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
     const target = editingField as 'address' | 'siteAddress';
     setSavingField(target);
     try {
-      if (target === 'address' && customer?.id) {
-        const updateReq: CustomerUpdateRequest = {
-          name: customer.name || '',
-          email: customer.email,
-          telephone: customer.telephone,
-          mobile: customer.mobile,
-          address: {
-            street: selectedMapAddress?.address || editValue || '',
-            city: selectedMapAddress?.city || customer.address?.city || '',
-            county: selectedMapAddress?.state || customer.address?.county || '',
-            postalCode: selectedMapAddress?.postalCode || customer.address?.postalCode || '',
-            country: selectedMapAddress?.country || customer.address?.country || '',
-          },
+      if (target === 'address') {
+        const addressObj = {
+          street: selectedMapAddress?.address || editValue || '',
+          city: selectedMapAddress?.city || customer?.address?.city || '',
+          county: selectedMapAddress?.state || customer?.address?.county || '',
+          postalCode: selectedMapAddress?.postalCode || customer?.address?.postalCode || '',
+          country: selectedMapAddress?.country || customer?.address?.country || '',
         };
-        const res = await customerService.updateCustomer(customer.id, updateReq);
-        onCustomerUpdate?.(res.data);
+        if (customer?.id) {
+          const updateReq: CustomerUpdateRequest = {
+            name: customer.name || '',
+            email: customer.email,
+            telephone: customer.telephone,
+            mobile: customer.mobile,
+            address: addressObj,
+          };
+          const res = await customerService.updateCustomer(customer.id, updateReq);
+          onCustomerUpdate?.(res.data);
+        } else {
+          const defaultName = `Customer for Job #${job.id || ''}`;
+          const createReq = {
+            name: defaultName,
+            address: addressObj,
+          };
+          const res = await customerService.createCustomer(createReq);
+          const newCust = res.data;
+          if (job.id && newCust.id) {
+            const jobRes = await jobService.updateJob(job.id, { customerId: newCust.id });
+            onJobUpdate?.(jobRes.data);
+          }
+          onCustomerUpdate?.(newCust);
+        }
       } else if (target === 'siteAddress' && job.id) {
         const updateReq: JobUpdateRequest = {
           address: {
@@ -184,8 +201,10 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
       }
       showSuccess('Updated address successfully');
       setEditingField(null);
-    } catch {
-      showError('Failed to update address');
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || err?.message || 'Failed to update address';
+      console.error('[handleSaveAddress] Failed:', err);
+      showError(msg);
     } finally {
       setSavingField(null);
     }
@@ -213,7 +232,47 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
   const handleSaveField = async (field: string) => {
     setSavingField(field);
     try {
-      if (['email', 'telephone', 'mobile', 'address'].includes(field)) {
+      if (field === 'customerName') {
+        if (customer?.id) {
+          const updateReq: CustomerUpdateRequest = {
+            name: editValue,
+            email: customer.email,
+            telephone: customer.telephone,
+            mobile: customer.mobile,
+            address: customer.address,
+          };
+          const res = await customerService.updateCustomer(customer.id, updateReq);
+          onCustomerUpdate?.(res.data);
+        } else {
+          const res = await customerService.createCustomer({ name: editValue });
+          const newCust = res.data;
+          if (job.id && newCust.id) {
+            const jobRes = await jobService.updateJob(job.id, { customerId: newCust.id });
+            onJobUpdate?.(jobRes.data);
+          }
+          onCustomerUpdate?.(newCust);
+        }
+      } else if (field === 'clientName') {
+        if (client?.id) {
+          const updateReq: ClientUpdateRequest = {
+            name: editValue,
+            email: client.email,
+            telephone: client.telephone,
+            mobile: client.mobile,
+            address: client.address,
+          };
+          const res = await companyClientService.updateClient(client.id, updateReq);
+          onClientUpdate?.(res.data);
+        } else {
+          const res = await companyClientService.createClient({ name: editValue });
+          const newClient = res.data;
+          if (job.id && newClient.id) {
+            const jobRes = await jobService.updateJob(job.id, { clientId: newClient.id });
+            onJobUpdate?.(jobRes.data);
+          }
+          onClientUpdate?.(newClient);
+        }
+      } else if (['email', 'telephone', 'mobile', 'address'].includes(field)) {
         if (customer?.id) {
           const updateReq: CustomerUpdateRequest = {
             name: customer.name || '',
@@ -234,6 +293,22 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
           };
           const res = await companyClientService.updateClient(client.id, updateReq);
           onClientUpdate?.(res.data);
+        } else {
+          const defaultName = `Customer for Job #${job.id || ''}`;
+          const createReq = {
+            name: defaultName,
+            email: field === 'email' ? editValue : undefined,
+            telephone: field === 'telephone' ? editValue : undefined,
+            mobile: field === 'mobile' ? editValue : undefined,
+            address: field === 'address' ? { street: editValue } : undefined,
+          };
+          const res = await customerService.createCustomer(createReq);
+          const newCust = res.data;
+          if (job.id && newCust.id) {
+            const jobRes = await jobService.updateJob(job.id, { customerId: newCust.id });
+            onJobUpdate?.(jobRes.data);
+          }
+          onCustomerUpdate?.(newCust);
         }
       } else if (field === 'status' && job.id) {
         const updateReq: JobUpdateRequest = { status: editValue as JobUpdateRequest['status'] };
@@ -242,8 +317,10 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
       }
       showSuccess('Updated successfully');
       setEditingField(null);
-    } catch {
-      showError('Failed to update');
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || err?.message || 'Failed to update';
+      console.error('[handleSaveField] Failed:', err);
+      showError(msg);
     } finally {
       setSavingField(null);
     }
@@ -406,11 +483,10 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
 
   const getRawFieldValue = (fieldId: number): string => {
     if (!job.fieldValues) return '';
+    // Look up by numeric id string first, then fallback to other keys
     const fieldValue = job.fieldValues[String(fieldId)];
-    if (fieldValue && typeof fieldValue === 'object' && 'value' in fieldValue) {
-      return String(fieldValue.value ?? '');
-    }
-    return fieldValue ? String(fieldValue) : '';
+    if (fieldValue === undefined || fieldValue === null) return '';
+    return extractFieldValue(fieldValue);
   };
 
   const getDisplayFieldValue = (field: JobTemplateFieldResponse): string => {
@@ -439,7 +515,11 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
       setSavingField(fieldKey);
       try {
         if (job.id && field.id !== undefined) {
-          const updatedFieldValues: Record<string, unknown> = { ...(job.fieldValues || {}) };
+          // Clean ALL existing field values before re-sending (backend may reject nested objects)
+          const updatedFieldValues: Record<string, unknown> = {};
+          Object.entries(job.fieldValues || {}).forEach(([k, v]) => {
+            updatedFieldValues[k] = extractFieldValue(v);
+          });
           if (editValue === '') {
             delete updatedFieldValues[String(field.id)];
           } else {
@@ -450,8 +530,10 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
         }
         showSuccess('Updated successfully');
         setEditingField(null);
-      } catch {
-        showError('Failed to update');
+      } catch (err: any) {
+        const msg = err?.response?.data?.message || err?.message || 'Failed to update';
+        console.error('[handleFieldSave] Failed:', err);
+        showError(msg);
       } finally {
         setSavingField(null);
       }
@@ -544,22 +626,12 @@ export const JobDetailsSection: React.FC<JobDetailsSectionProps> = ({
       </S.SectionHeader>
 
       <S.FieldsList>
-        <S.FieldRow>
-          <S.FieldIconContainer><PersonIcon /></S.FieldIconContainer>
-          <S.FieldLabel>Customer Name</S.FieldLabel>
-          <S.FieldValue $notSet={!customer?.name}>{customer?.name || 'No customer assigned'}</S.FieldValue>
-        </S.FieldRow>
-
-        <S.FieldRow>
-          <S.FieldIconContainer><BusinessIcon /></S.FieldIconContainer>
-          <S.FieldLabel>Client Name</S.FieldLabel>
-          <S.FieldValue $notSet={!client?.name}>{client?.name || 'Not set'}</S.FieldValue>
-        </S.FieldRow>
-
-        {renderEditableRow(<PhoneIcon />, 'Telephone', 'telephone', contactTelephone, canEditContact)}
-        {renderEditableRow(<EmailIcon />, 'Email', 'email', contactEmail, canEditContact)}
-        {renderEditableRow(<PhoneAndroidIcon />, 'Mobile', 'mobile', contactMobile, canEditContact)}
-        {renderEditableRow(<LocationOnIcon />, 'Address', 'address', contactAddress, canEditContact)}
+        {renderEditableRow(<PersonIcon />, 'Customer Name', 'customerName', customer?.name, true)}
+        {renderEditableRow(<BusinessIcon />, 'Client Name', 'clientName', client?.name, true)}
+        {renderEditableRow(<PhoneIcon />, 'Telephone', 'telephone', contactTelephone, true)}
+        {renderEditableRow(<EmailIcon />, 'Email', 'email', contactEmail, true)}
+        {renderEditableRow(<PhoneAndroidIcon />, 'Mobile', 'mobile', contactMobile, true)}
+        {renderEditableRow(<LocationOnIcon />, 'Address', 'address', contactAddress, true)}
 
         {editingField === 'address' && (
           <S.MapEditWrapper>

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/AddWorkLogModal.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/AddWorkLogModal.tsx
@@ -12,10 +12,13 @@ import { TextArea } from '../../../../../components/UI/Forms/TextArea';
 import { useSnackbar } from '../../../../../contexts/SnackbarContext';
 import { visitLogService } from '../../../../../services/api';
 import type { StepVisitLogResponse } from '../../../../../services/api';
+import type { JobWorkflowStepResponse } from '../../../../../services/api';
+import { StepSelectDropdown } from './JobWorkLogsTab.styles';
 import * as S from '../../../JobDetailsPage.styles';
 
 export interface AddWorkLogModalProps {
-  stepId: number;
+  stepId?: number | null;
+  steps?: JobWorkflowStepResponse[];
   editLog?: StepVisitLogResponse | null;
   onSuccess: () => void;
 }
@@ -25,6 +28,7 @@ type FormValues = {
   timeIn: string;
   timeOut: string;
   description: string;
+  stepId?: string;
 };
 
 const parseTime = (value?: string): Dayjs | null => {
@@ -193,7 +197,7 @@ const TimeField: React.FC<TimeFieldProps> = ({ name, label }) => {
   );
 };
 
-export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLog, onSuccess }) => {
+export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, steps, editLog, onSuccess }) => {
   const isEdit = !!editLog;
   const now = dayjs();
   const methods = useForm<FormValues>({
@@ -202,6 +206,7 @@ export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLo
       timeIn: editLog?.timeIn || now.format('HH:mm'),
       timeOut: editLog?.timeOut || now.format('HH:mm'),
       description: editLog?.description || '',
+      stepId: '',
     },
   });
   const { showError } = useSnackbar();
@@ -226,6 +231,12 @@ export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLo
         return;
       }
 
+      const targetStepId = stepId || (values.stepId ? Number(values.stepId) : null);
+      if (!isEdit && !targetStepId) {
+        showError('Step selection is required');
+        return;
+      }
+
       const payload = {
         visitDate: values.visitDate,
         timeIn: values.timeIn || undefined,
@@ -235,7 +246,7 @@ export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLo
 
       const request = isEdit
         ? visitLogService.updateVisitLog(editLog!.id!, payload)
-        : visitLogService.addVisitLog(stepId, payload);
+        : visitLogService.addVisitLog(targetStepId!, payload);
 
       request
         .then(() => onSuccess())
@@ -247,6 +258,21 @@ export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLo
     <FormProvider {...methods}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <S.ModalFormContainer>
+          {!stepId && !isEdit && steps && steps.length > 0 && (
+            <FormField label="Select Step" required>
+              <StepSelectDropdown
+                {...methods.register('stepId', { required: 'Step is required' })}
+              >
+                <option value="">Select Step</option>
+                {steps.map((s, idx) => (
+                  <option key={s.id} value={s.id}>
+                    {idx + 1}. {s.name || `Step ${idx + 1}`}
+                  </option>
+                ))}
+              </StepSelectDropdown>
+            </FormField>
+          )}
+
           <FormField label="Visit Date" required>
             <Input name="visitDate" type="date" placeHolder="Select date" fullWidth />
           </FormField>
@@ -261,6 +287,7 @@ export const AddWorkLogModal: React.FC<AddWorkLogModalProps> = ({ stepId, editLo
           </FormField>
         </S.ModalFormContainer>
       </LocalizationProvider>
+
     </FormProvider>
   );
 };

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobCustomFieldsTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobCustomFieldsTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { JobResponse, JobTemplateFieldResponse } from '../../../../../services/api';
+import { extractFieldValue } from '../../../../../utils/fieldValueHelper';
 import * as S from '../../../JobDetailsPage.styles';
 
 interface JobCustomFieldsTabProps {
@@ -42,12 +43,7 @@ export const JobCustomFieldsTab: React.FC<JobCustomFieldsTabProps> = ({ job, tem
                       <S.FieldsGroupTitle>Required Fields</S.FieldsGroupTitle>
                       {requiredFields.map(([key, fieldValueResponse]) => {
                         const fieldDef = fieldDefinitionMap.get(key);
-                        const value =
-                          fieldValueResponse &&
-                          typeof fieldValueResponse === 'object' &&
-                          'value' in fieldValueResponse
-                            ? String(fieldValueResponse.value || '-')
-                            : String(fieldValueResponse || '-');
+                        const value = extractFieldValue(fieldValueResponse);
 
                         const label = fieldDef?.label || key;
                         const fieldType = fieldDef?.jobFieldType || 'TEXT';
@@ -74,12 +70,7 @@ export const JobCustomFieldsTab: React.FC<JobCustomFieldsTabProps> = ({ job, tem
                       )}
                       {optionalFields.map(([key, fieldValueResponse]) => {
                         const fieldDef = fieldDefinitionMap.get(key);
-                        const value =
-                          fieldValueResponse &&
-                          typeof fieldValueResponse === 'object' &&
-                          'value' in fieldValueResponse
-                            ? String(fieldValueResponse.value || '-')
-                            : String(fieldValueResponse || '-');
+                        const value = extractFieldValue(fieldValueResponse);
 
                         const label = fieldDef?.label || key;
                         const fieldType = fieldDef?.jobFieldType || 'TEXT';

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
@@ -493,3 +493,22 @@ export const NotePopupNoteText = styled(Typography)(({ theme }) => ({
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
 }));
+
+export const AllStepCircle = styled(StepCircle)(() => ({
+  fontSize: rem(12),
+}));
+
+export const StepNameText = styled(DurationText)(() => ({
+  fontWeight: 500,
+}));
+
+export const StepSelectDropdown = styled('select')(({ theme }) => ({
+  width: '100%',
+  height: '40px',
+  borderRadius: '8px',
+  borderColor: theme.palette.colors.grey_200,
+  padding: '0 12px',
+  outline: 'none',
+  fontSize: '14px',
+  backgroundColor: theme.palette.colors.white,
+}));

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
@@ -4,64 +4,167 @@ import { floowColors } from '../../../../../theme/colors';
 
 export { EmptyFeedBox } from './StepActivityTab.styles';
 
-// ─── Layout ───────────────────────────────────────────────────────────────────
+// ─── Outer Layout (Rail + Right Content) ──────────────────────────────────────
 
-export const WorkLogsLayout = styled(Box)(({ theme }) => ({
+export const WorkLogsOuterLayout = styled(Box)(({ theme }) => ({
   display: 'flex',
-  flexDirection: 'column',
+  flexDirection: 'row',
   width: '100%',
   backgroundColor: theme.palette.colors.white,
   borderRadius: rem(12),
-  border: `1px solid ${theme.palette.colors.grey_200}`,
+  border: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
   overflow: 'hidden',
+  position: 'relative',
 }));
 
-// ─── Top Horizontal Steps Navigation ──────────────────────────────────────────
+// ─── Left Steps Rail (max 2rem wide) ──────────────────────────────────────────
 
-export const StepsNavContainer = styled(Box)(({ theme }) => ({
+export const StepsRail = styled(Box)(({ theme }) => ({
+  width: rem(56),
+  maxWidth: rem(56),
+  flexShrink: 0,
+  borderRight: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
+  backgroundColor: theme.palette.colors.white,
   display: 'flex',
+  flexDirection: 'column',
   alignItems: 'center',
-  gap: theme.spacing(1),
-  padding: theme.spacing(1.5, 2),
-  overflowX: 'auto',
-  borderBottom: `1px solid ${theme.palette.colors.grey_100}`,
+  paddingTop: rem(10),
+  paddingBottom: rem(10),
+  zIndex: 2,
+}));
+
+export const StepsRailHeader = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: rem(4),
+  marginBottom: rem(8),
+  width: '100%',
+}));
+
+export const StepsRailTitle = styled(Typography)(({ theme }) => ({
+  fontSize: rem(7),
+  fontWeight: Bold._700,
+  color: theme.palette.text.secondary,
+  letterSpacing: rem(0.5),
+  textTransform: 'uppercase',
+  lineHeight: 1,
+  textAlign: 'center',
+}));
+
+// ─── Search Wrapper & Input ───────────────────────────────────────────────────
+// Input is absolutely positioned, extends to the RIGHT of the rail, overlaying
+// the content area. No overflow clipping since it stays within the outer container.
+
+export const StepSearchWrapper = styled(Box)(() => ({
+  position: 'relative',
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
+
+export const StepSearchInput = styled('input')(({ theme }) => ({
+  position: 'absolute',
+  left: '100%',        // starts right at the rail's right edge (3.5rem)
+  top: '50%',
+  transform: 'translateY(-50%)',
+  width: rem(72),
+  height: rem(26),
+  border: `${rem(1)} solid ${theme.palette.colors.grey_300}`,
+  borderLeft: 'none',
+  borderRadius: `0 ${rem(4)} ${rem(4)} 0`,
+  backgroundColor: theme.palette.colors.white,
+  fontSize: rem(12),
+  padding: `0 ${rem(6)}`,
+  outline: 'none',
+  zIndex: 10,
+  boxShadow: `${rem(2)} ${rem(2)} ${rem(8)} rgba(0,0,0,0.1)`,
+  // Remove number-type spin arrows
+  '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': {
+    appearance: 'none',
+    margin: 0,
+  },
+  '&[type=number]': {
+    MozAppearance: 'textfield',
+  },
+  '&:focus': {
+    borderColor: '#101a32',
+    boxShadow: `${rem(2)} ${rem(2)} ${rem(10)} rgba(16,26,50,0.15)`,
+  },
+  '&::placeholder': {
+    color: theme.palette.text.secondary,
+    fontSize: rem(11),
+  },
+}));
+
+// ─── Step Bubbles List ────────────────────────────────────────────────────────
+
+export const StepsBubbleList = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  flex: 1,
+  overflowY: 'auto',
+  overflowX: 'visible',
+  width: '100%',
+  paddingTop: rem(4),
   '&::-webkit-scrollbar': {
-    height: rem(4),
+    width: rem(2),
   },
   '&::-webkit-scrollbar-thumb': {
-    backgroundColor: theme.palette.colors.grey_300,
-    borderRadius: rem(4),
+    backgroundColor: floowColors.tailwind.gray[300],
+    borderRadius: rem(2),
   },
 }));
 
-export const StepBadge = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'isActive',
-})<{ isActive?: boolean }>(({ theme, isActive }) => ({
+export const StepBubbleItem = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+}));
+
+export const StepConnector = styled(Box)(({ theme }) => ({
+  width: rem(2),
+  height: rem(10),
+  backgroundColor: theme.palette.colors.grey_200,
+  flexShrink: 0,
+}));
+
+export const StepCircle = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isActive' && prop !== 'stepColor',
+})<{ isActive?: boolean; stepColor?: string }>(({ theme, isActive, stepColor }) => ({
+  // Fills most of the 3.5rem (56px) rail — 44px circle, 6px padding each side
+  width: rem(44),
+  height: rem(44),
+  borderRadius: '50%',
+  backgroundColor: isActive ? '#101a32' : theme.palette.colors.white,
+  border: `${rem(2.5)} solid ${isActive ? '#101a32' : (stepColor || theme.palette.colors.grey_300)}`,
+  color: isActive ? floowColors.white : theme.palette.text.primary,
+  fontSize: rem(14),
+  fontWeight: Bold._700,
   display: 'flex',
   alignItems: 'center',
-  gap: rem(6),
-  padding: `${rem(6)} ${rem(12)}`,
-  borderRadius: rem(6),
-  border: `1px solid ${isActive ? '#101a32' : theme.palette.colors.grey_200}`,
-  backgroundColor: isActive ? '#101a32' : theme.palette.colors.white,
-  color: isActive ? floowColors.white : theme.palette.text.primary,
-  fontSize: rem(13),
-  fontWeight: Bold._600,
+  justifyContent: 'center',
   cursor: 'pointer',
-  whiteSpace: 'nowrap',
+  userSelect: 'none',
+  flexShrink: 0,
+  position: 'relative',
   transition: 'all 0.15s ease',
   '&:hover': {
     borderColor: '#101a32',
+    backgroundColor: isActive ? '#101a32' : floowColors.tailwind.gray[50],
   },
 }));
 
-export const StepDot = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'dotColor',
-})<{ dotColor?: string }>(({ dotColor }) => ({
-  width: rem(8),
-  height: rem(8),
-  borderRadius: '50%',
-  backgroundColor: dotColor || floowColors.white,
+// ─── Right Content Column ─────────────────────────────────────────────────────
+
+export const WorkLogsLayout = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
 }));
 
 // ─── Summary Section ──────────────────────────────────────────────────────────
@@ -71,14 +174,13 @@ export const SummarySection = styled(Box)(({ theme }) => ({
   flexDirection: 'row',
   gap: theme.spacing(2),
   padding: theme.spacing(3),
-  borderBottom: `1px solid ${theme.palette.colors.grey_200}`,
+  borderBottom: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
   backgroundColor: floowColors.tailwind.gray[50],
   [theme.breakpoints.down('lg')]: {
     flexDirection: 'column',
   },
 }));
 
-// Left Black Box
 export const TrackingBox = styled(Box)(({ theme }) => ({
   flex: 1,
   backgroundColor: '#101a32',
@@ -94,7 +196,7 @@ export const TrackingBox = styled(Box)(({ theme }) => ({
   },
 }));
 
-export const TimerIconBox = styled(Box)(({ theme }) => ({
+export const TimerIconBox = styled(Box)(() => ({
   width: rem(64),
   height: rem(64),
   borderRadius: rem(16),
@@ -102,6 +204,7 @@ export const TimerIconBox = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  flexShrink: 0,
 }));
 
 export const TrackingInfo = styled(Box)(() => ({
@@ -114,7 +217,7 @@ export const TrackingLabel = styled(Typography)(() => ({
   fontSize: rem(11),
   fontWeight: Bold._700,
   color: 'rgba(255, 255, 255, 0.6)',
-  letterSpacing: '0.5px',
+  letterSpacing: rem(0.5),
   textTransform: 'uppercase',
 }));
 
@@ -125,7 +228,6 @@ export const TrackingTime = styled(Typography)(() => ({
   color: floowColors.white,
 }));
 
-// Right Grid
 export const StatsGrid = styled(Box)(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
@@ -142,7 +244,7 @@ export const StatsGrid = styled(Box)(({ theme }) => ({
 
 export const StatBox = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.colors.white,
-  border: `1px solid ${theme.palette.colors.grey_200}`,
+  border: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
   borderRadius: rem(12),
   padding: theme.spacing(2.5, 3),
   display: 'flex',
@@ -160,7 +262,7 @@ export const StatLabel = styled(Typography)(({ theme }) => ({
   fontSize: rem(11),
   fontWeight: Bold._700,
   color: theme.palette.text.secondary,
-  letterSpacing: '0.5px',
+  letterSpacing: rem(0.5),
   textTransform: 'uppercase',
 }));
 
@@ -173,90 +275,123 @@ export const StatValue = styled(Typography)(({ theme }) => ({
 
 // ─── Table Section ────────────────────────────────────────────────────────────
 
-export const TableContainer = styled(Box)(({ theme }) => ({
-  width: '100%',
-  overflowX: 'auto',
-  minHeight: rem(400),
+export const TableSectionTitle = styled(Typography)(({ theme }) => ({
+  fontSize: rem(12),
+  fontWeight: Bold._700,
+  color: theme.palette.text.secondary,
+  letterSpacing: rem(0.5),
+  textTransform: 'uppercase',
+  padding: theme.spacing(3, 3, 2, 3),
 }));
 
-export const Table = styled('table')(({ theme }) => ({
+export const TableContainer = styled(Box)(() => ({
+  width: '100%',
+  overflowX: 'auto',
+  minHeight: rem(200),
+  '&::-webkit-scrollbar': {
+    height: rem(4),
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: floowColors.tailwind.gray[300],
+    borderRadius: rem(2),
+  },
+}));
+
+export const Table = styled('table')(() => ({
   width: '100%',
   borderCollapse: 'collapse',
   textAlign: 'left',
-  minWidth: rem(800),
+  minWidth: rem(560),
 }));
 
 export const Th = styled('th')(({ theme }) => ({
-  padding: theme.spacing(2, 3),
+  padding: `${rem(10)} ${rem(16)}`,
   fontSize: rem(11),
   fontWeight: Bold._700,
   color: theme.palette.text.secondary,
   textTransform: 'uppercase',
-  letterSpacing: '0.5px',
-  borderBottom: `1px solid ${theme.palette.colors.grey_200}`,
+  letterSpacing: rem(0.5),
+  borderBottom: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
   backgroundColor: floowColors.tailwind.gray[50],
+  whiteSpace: 'nowrap',
 }));
 
-export const Td = styled('td')(({ theme }) => ({
-  padding: theme.spacing(2.5, 3),
-  fontSize: rem(14),
-  color: theme.palette.text.primary,
-  borderBottom: `1px solid ${theme.palette.colors.grey_100}`,
-  verticalAlign: 'middle',
+// Header row — no pointer cursor, no hover highlight
+export const Tr = styled('tr')(() => ({
+  // header row only
 }));
 
-export const Tr = styled('tr')(({ theme }) => ({
+// Data rows — 3.5rem height, clickable
+export const DataTr = styled('tr')(({ theme }) => ({
+  height: rem(56),
+  maxHeight: rem(56),
+  cursor: 'pointer',
   transition: 'background-color 0.15s ease',
   '&:hover': {
     backgroundColor: floowColors.tailwind.gray[50],
   },
 }));
 
+export const Td = styled('td')(({ theme }) => ({
+  padding: `0 ${rem(16)}`,
+  height: rem(56),
+  maxHeight: rem(56),
+  fontSize: rem(13),
+  color: theme.palette.text.primary,
+  borderBottom: `${rem(1)} solid ${theme.palette.colors.grey_100}`,
+  verticalAlign: 'middle',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+}));
+
+// Notes cell — truncated with ellipsis
+export const NotesTd = styled('td')(({ theme }) => ({
+  padding: `0 ${rem(16)}`,
+  height: rem(56),
+  maxHeight: rem(56),
+  maxWidth: rem(180),
+  fontSize: rem(13),
+  color: theme.palette.text.secondary,
+  borderBottom: `${rem(1)} solid ${theme.palette.colors.grey_100}`,
+  verticalAlign: 'middle',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+}));
+
 export const UserBadge = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(1.5),
+  gap: rem(6),
   fontWeight: Bold._600,
+  fontSize: rem(13),
 }));
 
 export const UserAvatar = styled(Box)(({ theme }) => ({
-  width: rem(32),
-  height: rem(32),
+  width: rem(20),
+  height: rem(20),
   borderRadius: '50%',
   backgroundColor: theme.palette.primary.main,
   color: floowColors.white,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontSize: rem(12),
+  fontSize: rem(9),
   fontWeight: Bold._700,
+  flexShrink: 0,
 }));
 
 export const DurationText = styled(Typography)(({ theme }) => ({
-  fontSize: rem(14),
+  fontSize: rem(13),
   fontWeight: Bold._700,
   color: theme.palette.text.primary,
+  lineHeight: 1,
 }));
 
-export const ActionCell = styled(Box)(({ theme }) => ({
+export const ActionCell = styled(Box)(() => ({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(1),
-}));
-
-export const NotesText = styled(Typography)(({ theme }) => ({
-  fontSize: rem(13.5),
-  color: theme.palette.text.secondary,
-  lineHeight: 1.5,
-}));
-
-export const TableSectionTitle = styled(Typography)(({ theme }) => ({
-  fontSize: rem(12),
-  fontWeight: Bold._700,
-  color: theme.palette.text.secondary,
-  letterSpacing: '0.5px',
-  textTransform: 'uppercase',
-  padding: theme.spacing(3, 3, 2, 3),
+  gap: rem(2),
 }));
 
 export const EmptyStateRow = styled('td')(({ theme }) => ({
@@ -266,3 +401,95 @@ export const EmptyStateRow = styled('td')(({ theme }) => ({
   fontSize: rem(14),
 }));
 
+// ─── Note Detail Popup ────────────────────────────────────────────────────────
+
+// Backdrop covers the full viewport for click-outside detection.
+// The card is independently fixed-positioned (not flex-centred here).
+export const NotePopupBackdrop = styled(Box)(() => ({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 1300,
+  backgroundColor: 'rgba(0, 0, 0, 0.22)',
+}));
+
+// Card is fixed-positioned and centred on the clicked row.
+// `yOffset` (px from top of viewport) is the row's vertical mid-point.
+export const NotePopupCard = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'yOffset',
+})<{ yOffset?: number }>(({ theme, yOffset }) => ({
+  position: 'fixed',
+  // Horizontally centred in the viewport
+  left: '50%',
+  // Vertically centred on the clicked row; fall back to viewport centre
+  top: yOffset !== undefined ? `${yOffset}px` : '50vh',
+  transform: 'translate(-50%, -50%)',
+  zIndex: 1301,
+  backgroundColor: theme.palette.colors.white,
+  borderRadius: rem(12),
+  boxShadow: `0 ${rem(8)} ${rem(32)} rgba(0,0,0,0.16)`,
+  padding: `${rem(14)} ${rem(18)}`,
+  minWidth: rem(180),
+  maxWidth: rem(440),
+  width: 'fit-content',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(6),
+  border: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
+  [theme.breakpoints.down('sm')]: {
+    maxWidth: `calc(100vw - ${rem(32)})`,
+    width: `calc(100vw - ${rem(32)})`,
+  },
+}));
+
+// First line: start→end time + ✕ button
+export const NotePopupHeader = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: rem(20),
+}));
+
+export const NotePopupTimeValue = styled(Typography)(({ theme }) => ({
+  fontSize: rem(13),
+  fontWeight: Bold._600,
+  color: theme.palette.text.primary,
+  whiteSpace: 'nowrap',
+  lineHeight: 1,
+}));
+
+export const NotePopupCloseBtn = styled('button')(({ theme }) => ({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: theme.palette.text.secondary,
+  padding: 0,
+  lineHeight: 1,
+  fontSize: rem(14),
+  borderRadius: '50%',
+  width: rem(18),
+  height: rem(18),
+  flexShrink: 0,
+  transition: 'color 0.12s, background-color 0.12s',
+  '&:hover': {
+    color: theme.palette.text.primary,
+    backgroundColor: floowColors.tailwind.gray[100],
+  },
+}));
+
+export const NotePopupDivider = styled('hr')(({ theme }) => ({
+  border: 'none',
+  borderTop: `${rem(1)} solid ${theme.palette.colors.grey_100}`,
+  margin: 0,
+}));
+
+// Second line: full note text — wraps naturally, no truncation
+export const NotePopupNoteText = styled(Typography)(({ theme }) => ({
+  fontSize: rem(13),
+  color: theme.palette.text.secondary,
+  lineHeight: 1.5,
+  wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap',
+}));

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { CircularProgress, Tooltip, IconButton } from '@mui/material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import SearchIcon from '@mui/icons-material/Search';
 import type {
   JobResponse,
   JobWorkflowStepResponse,
@@ -60,12 +61,24 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   const { showSuccess, showError } = useSnackbar();
   const { setGlobalModalOuterProps, resetGlobalModalOuterProps } = useGlobalModalOuterContext();
 
+  // ── Data state ──────────────────────────────────────────────────────────────
   const [loadingWorkflow, setLoadingWorkflow] = useState(true);
   const [steps, setSteps] = useState<JobWorkflowStepResponse[]>([]);
   const [selectedStepId, setSelectedStepId] = useState<number | null>(null);
   const [visitLogs, setVisitLogs] = useState<StepVisitLogResponse[]>([]);
   const [totalMinutes, setTotalMinutes] = useState(0);
   const [loadingLogs, setLoadingLogs] = useState(false);
+
+  // ── UI state ─────────────────────────────────────────────────────────────────
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [popupLog, setPopupLog] = useState<StepVisitLogResponse | null>(null);
+  // Vertical centre (px from viewport top) of the row that was clicked
+  const [popupY, setPopupY] = useState<number>(0);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // ── Data fetching ────────────────────────────────────────────────────────────
 
   const fetchWorkflow = useCallback(async () => {
     if (!job.id) return;
@@ -102,6 +115,8 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   useEffect(() => { fetchWorkflow(); }, [fetchWorkflow]);
   useEffect(() => { fetchVisitLogs(); }, [fetchVisitLogs]);
 
+  // ── Derived values ───────────────────────────────────────────────────────────
+
   const summary = useMemo(() => {
     const totalEntries = visitLogs.length;
     const totalHours = totalMinutes / 60;
@@ -110,9 +125,56 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   }, [visitLogs, totalMinutes]);
 
   const selectedStep = steps.find((s) => s.id === selectedStepId);
-  const selectedStepIdx = steps.findIndex((s) => s.id === selectedStepId);
 
-  const openModal = (editLog?: StepVisitLogResponse) => {
+  // ── Search handler ───────────────────────────────────────────────────────────
+
+  const handleSearchSubmit = useCallback(() => {
+    const num = parseInt(searchValue, 10);
+    if (isNaN(num) || num < 1 || num > steps.length) {
+      showError('This step not exist');
+      setSearchValue('');
+      setSearchOpen(false);
+      return;
+    }
+    const targetStep = steps[num - 1];
+    if (targetStep?.id) setSelectedStepId(targetStep.id);
+    setSearchValue('');
+    setSearchOpen(false);
+  }, [searchValue, steps, showError]);
+
+  const handleSearchIconClick = useCallback(() => {
+    if (searchOpen) {
+      setSearchOpen(false);
+      setSearchValue('');
+    } else {
+      setSearchOpen(true);
+      // Focus the input after it mounts
+      setTimeout(() => searchInputRef.current?.focus(), 30);
+    }
+  }, [searchOpen]);
+
+  const handleSearchBlur = useCallback(() => {
+    // Small delay so that Enter-key submit can clear state before blur fires
+    setTimeout(() => {
+      setSearchOpen(false);
+      setSearchValue('');
+    }, 120);
+  }, []);
+
+  // ── Modal helpers ────────────────────────────────────────────────────────────
+
+  const handleRowClick = useCallback(
+    (log: StepVisitLogResponse, e: React.MouseEvent<HTMLTableRowElement>) => {
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      const rawY = rect.top + rect.height / 2;
+      // Clamp so the popup card (est. ~100px tall) never overflows the viewport
+      const clampedY = Math.max(60, Math.min(rawY, window.innerHeight - 60));
+      setPopupY(clampedY);
+      setPopupLog(log);
+    },
+    []
+  );
+  const openModal = useCallback((editLog?: StepVisitLogResponse) => {
     if (!selectedStepId) return;
     setGlobalModalOuterProps({
       isOpen: true,
@@ -130,9 +192,9 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
         />
       ),
     });
-  };
+  }, [selectedStepId, setGlobalModalOuterProps, resetGlobalModalOuterProps, showSuccess, fetchVisitLogs]);
 
-  const handleDelete = async (visitLogId: number) => {
+  const handleDelete = useCallback(async (visitLogId: number) => {
     try {
       await visitLogService.deleteVisitLog(visitLogId);
       showSuccess('Work log deleted');
@@ -140,9 +202,9 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
     } catch {
       showError('Failed to delete work log');
     }
-  };
+  }, [showSuccess, showError, fetchVisitLogs]);
 
-  // ── Guards ──────────────────────────────────────────────────────────────────
+  // ── Guards ───────────────────────────────────────────────────────────────────
 
   if (loadingWorkflow) return <Loader centered minHeight="300px" />;
 
@@ -150,150 +212,251 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
     return (
       <WS.EmptyFeedBox sx={{ minHeight: 300 }}>
         <AccessTimeIcon sx={{ fontSize: rem(48), color: 'grey.200' }} />
-        <span style={{ fontSize: rem(14), color: 'inherit' }}>
-          No workflow steps found for this job.
-        </span>
+        <span>No workflow steps found for this job.</span>
       </WS.EmptyFeedBox>
     );
   }
 
-  // ── Render ──────────────────────────────────────────────────────────────────
+  // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <WS.WorkLogsLayout>
-      {/* ── Top: Horizontal Steps Navigation ─────────────────────────────── */}
-      <WS.StepsNavContainer>
-        {steps.map((step, idx) => {
-          const isActive = selectedStepId === step.id;
-          return (
-            <WS.StepBadge
-              key={step.id}
-              isActive={isActive}
-              onClick={() => step.id && setSelectedStepId(step.id)}
-            >
-              <WS.StepDot dotColor={getStepColor(idx)} />
-              {idx + 1}. {step.name || `Step ${idx + 1}`}
-            </WS.StepBadge>
-          );
-        })}
-      </WS.StepsNavContainer>
+    <WS.WorkLogsOuterLayout>
 
-      {/* ── Summary Section ────────────────────────────────────────────────── */}
-      <WS.SummarySection>
-        <WS.TrackingBox>
-          <WS.TimerIconBox>
-            <AccessTimeIcon sx={{ fontSize: rem(32), color: 'white' }} />
-          </WS.TimerIconBox>
-          <WS.TrackingInfo>
-            <WS.TrackingLabel>
-              CURRENTLY TRACKING - {selectedStep?.name || 'STEP'}
-            </WS.TrackingLabel>
-            <WS.TrackingTime>{formatMinutes(totalMinutes)}</WS.TrackingTime>
-          </WS.TrackingInfo>
-        </WS.TrackingBox>
+      {/* ── Left Steps Rail ───────────────────────────────────────────────── */}
+      <WS.StepsRail>
+        <WS.StepsRailHeader>
+          <WS.StepsRailTitle>STEPS</WS.StepsRailTitle>
 
-        <WS.StatsGrid>
-          <WS.StatBox>
-            <WS.StatLabel>Total Hours</WS.StatLabel>
-            <WS.StatValue>{summary.totalHours.toFixed(1)}h</WS.StatValue>
-          </WS.StatBox>
-          <WS.AddLogBox>
-            <Button
-              size="medium"
-              startIcon={<AddIcon />}
-              onClick={() => openModal()}
-              disabled={!selectedStepId}
-              fullWidth
-            >
-              Add Work Log
-            </Button>
-          </WS.AddLogBox>
-          <WS.StatBox>
-            <WS.StatLabel>Entries</WS.StatLabel>
-            <WS.StatValue>{summary.totalEntries}</WS.StatValue>
-          </WS.StatBox>
-          <WS.StatBox>
-            <WS.StatLabel>Avg Per Entry</WS.StatLabel>
-            <WS.StatValue>{formatMinutes(summary.avgMinutes)}</WS.StatValue>
-          </WS.StatBox>
-        </WS.StatsGrid>
-      </WS.SummarySection>
+          {/* Search icon + expanding input */}
+          <WS.StepSearchWrapper>
+            <Tooltip title={searchOpen ? 'Close' : 'Jump to step'} placement="right">
+              <IconButton
+                size="medium"
+                onClick={handleSearchIconClick}
+                sx={{ width: rem(32), height: rem(32), padding: 0 }}
+              >
+                <SearchIcon sx={{ fontSize: rem(20) }} />
+              </IconButton>
+            </Tooltip>
 
-      {/* ── Table Section ──────────────────────────────────────────────────── */}
-      <WS.TableSectionTitle>Recent Entries</WS.TableSectionTitle>
-      <WS.TableContainer>
-        <WS.Table>
-          <thead>
-            <WS.Tr>
-              <WS.Th>Date</WS.Th>
-              <WS.Th>Who</WS.Th>
-              <WS.Th>Start &rarr; End</WS.Th>
-              <WS.Th>Duration</WS.Th>
-              <WS.Th>Notes</WS.Th>
-              <WS.Th>Action</WS.Th>
-            </WS.Tr>
-          </thead>
-          <tbody>
-            {loadingLogs ? (
-              <WS.Tr>
-                <WS.EmptyStateRow colSpan={6}>
-                  <CircularProgress size={24} />
-                </WS.EmptyStateRow>
-              </WS.Tr>
-            ) : visitLogs.length === 0 ? (
-              <WS.Tr>
-                <WS.EmptyStateRow colSpan={6}>
-                  No WorkLog Available
-                </WS.EmptyStateRow>
-              </WS.Tr>
-            ) : (
-              visitLogs.map((log) => {
-                const username = (log as Record<string, any>).loggedByUsername || '-';
-                const initials = username !== '-' ? username.substring(0, 2).toUpperCase() : '?';
-
-                return (
-                  <WS.Tr key={log.id}>
-                    <WS.Td>{formatDate(log.visitDate)}</WS.Td>
-                    <WS.Td>
-                      <WS.UserBadge>
-                        <WS.UserAvatar>{initials}</WS.UserAvatar>
-                        {username}
-                      </WS.UserBadge>
-                    </WS.Td>
-                    <WS.Td>
-                      {formatTime(log.timeIn)} &rarr; {formatTime(log.timeOut)}
-                    </WS.Td>
-                    <WS.Td>
-                      <WS.DurationText>{formatMinutes(log.workedMinutes)}</WS.DurationText>
-                    </WS.Td>
-                    <WS.Td>
-                      <WS.NotesText>{log.description || '-'}</WS.NotesText>
-                    </WS.Td>
-                    <WS.Td>
-                      <WS.ActionCell>
-                        <Tooltip title="Edit">
-                          <IconButton size="small" onClick={() => openModal(log)}>
-                            <EditIcon sx={{ fontSize: rem(18) }} />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Delete">
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => log.id && handleDelete(log.id)}
-                          >
-                            <DeleteIcon sx={{ fontSize: rem(18) }} />
-                          </IconButton>
-                        </Tooltip>
-                      </WS.ActionCell>
-                    </WS.Td>
-                  </WS.Tr>
-                );
-              })
+            {searchOpen && (
+              <WS.StepSearchInput
+                ref={searchInputRef}
+                type="number"
+                value={searchValue}
+                placeholder="#"
+                min={1}
+                max={steps.length}
+                onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleSearchSubmit();
+                  if (e.key === 'Escape') {
+                    setSearchOpen(false);
+                    setSearchValue('');
+                  }
+                }}
+                onBlur={handleSearchBlur}
+              />
             )}
-          </tbody>
-        </WS.Table>
-      </WS.TableContainer>
-    </WS.WorkLogsLayout>
+          </WS.StepSearchWrapper>
+        </WS.StepsRailHeader>
+
+        {/* Step circles with connectors */}
+        <WS.StepsBubbleList>
+          {steps.map((step, idx) => {
+            const isActive = selectedStepId === step.id;
+            return (
+              <WS.StepBubbleItem key={step.id}>
+                {idx > 0 && <WS.StepConnector />}
+                <Tooltip
+                  title={`${idx + 1}. ${step.name || `Step ${idx + 1}`}`}
+                  placement="right"
+                  arrow
+                >
+                  <WS.StepCircle
+                    isActive={isActive}
+                    stepColor={getStepColor(idx)}
+                    onClick={() => step.id && setSelectedStepId(step.id)}
+                  >
+                    {idx + 1}
+                  </WS.StepCircle>
+                </Tooltip>
+              </WS.StepBubbleItem>
+            );
+          })}
+        </WS.StepsBubbleList>
+      </WS.StepsRail>
+
+      {/* ── Right Content Column ──────────────────────────────────────────── */}
+      <WS.WorkLogsLayout>
+
+        {/* ── Summary Section ─────────────────────────────────────────────── */}
+        <WS.SummarySection>
+          <WS.TrackingBox>
+            <WS.TimerIconBox>
+              <AccessTimeIcon sx={{ fontSize: rem(32), color: 'white' }} />
+            </WS.TimerIconBox>
+            <WS.TrackingInfo>
+              <WS.TrackingLabel>
+                CURRENTLY TRACKING — {selectedStep?.name?.toUpperCase() || 'STEP'}
+              </WS.TrackingLabel>
+              <WS.TrackingTime>{formatMinutes(totalMinutes)}</WS.TrackingTime>
+            </WS.TrackingInfo>
+          </WS.TrackingBox>
+
+          <WS.StatsGrid>
+            <WS.StatBox>
+              <WS.StatLabel>Total Hours</WS.StatLabel>
+              <WS.StatValue>{summary.totalHours.toFixed(1)}h</WS.StatValue>
+            </WS.StatBox>
+            <WS.AddLogBox>
+              <Button
+                size="medium"
+                startIcon={<AddIcon />}
+                onClick={() => openModal()}
+                disabled={!selectedStepId}
+                fullWidth
+              >
+                Add Work Log
+              </Button>
+            </WS.AddLogBox>
+            <WS.StatBox>
+              <WS.StatLabel>Entries</WS.StatLabel>
+              <WS.StatValue>{summary.totalEntries}</WS.StatValue>
+            </WS.StatBox>
+            <WS.StatBox>
+              <WS.StatLabel>Avg Per Entry</WS.StatLabel>
+              <WS.StatValue>{formatMinutes(summary.avgMinutes)}</WS.StatValue>
+            </WS.StatBox>
+          </WS.StatsGrid>
+        </WS.SummarySection>
+
+        {/* ── Table Section ────────────────────────────────────────────────── */}
+        <WS.TableSectionTitle>Recent Entries</WS.TableSectionTitle>
+        <WS.TableContainer>
+          <WS.Table>
+            <thead>
+              {/* Header row — not clickable */}
+              <WS.Tr>
+                <WS.Th>Date</WS.Th>
+                <WS.Th>Who</WS.Th>
+                <WS.Th>Start → End</WS.Th>
+                <WS.Th>Duration</WS.Th>
+                <WS.Th>Notes</WS.Th>
+                <WS.Th>Action</WS.Th>
+              </WS.Tr>
+            </thead>
+            <tbody>
+              {loadingLogs ? (
+                <tr>
+                  <WS.EmptyStateRow colSpan={6}>
+                    <CircularProgress size={20} />
+                  </WS.EmptyStateRow>
+                </tr>
+              ) : visitLogs.length === 0 ? (
+                <tr>
+                  <WS.EmptyStateRow colSpan={6}>
+                    No WorkLog Available
+                  </WS.EmptyStateRow>
+                </tr>
+              ) : (
+                visitLogs.map((log) => {
+                  const username = (log as Record<string, any>).loggedByUsername || '-';
+                  const initials = username !== '-'
+                    ? username.substring(0, 2).toUpperCase()
+                    : '?';
+
+                  return (
+                    /* Data row — clicking anywhere opens the popup */
+                    <WS.DataTr
+                      key={log.id}
+                      onClick={(e) => handleRowClick(log, e)}
+                    >
+                      <WS.Td>{formatDate(log.visitDate)}</WS.Td>
+
+                      <WS.Td>
+                        <WS.UserBadge>
+                          <WS.UserAvatar>{initials}</WS.UserAvatar>
+                          {username}
+                        </WS.UserBadge>
+                      </WS.Td>
+
+                      <WS.Td>
+                        {formatTime(log.timeIn)} → {formatTime(log.timeOut)}
+                      </WS.Td>
+
+                      <WS.Td>
+                        <WS.DurationText>{formatMinutes(log.workedMinutes)}</WS.DurationText>
+                      </WS.Td>
+
+                      {/* Notes — truncated, full text in title attr for native tooltip */}
+                      <WS.NotesTd title={log.description || undefined}>
+                        {log.description || '-'}
+                      </WS.NotesTd>
+
+                      {/* Action buttons — stop propagation so row click doesn't fire */}
+                      <WS.Td onClick={(e) => e.stopPropagation()}>
+                        <WS.ActionCell>
+                          <Tooltip title="Edit">
+                            <IconButton
+                              size="small"
+                              onClick={() => openModal(log)}
+                            >
+                              <EditIcon sx={{ fontSize: rem(16) }} />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Delete">
+                            <IconButton
+                              size="small"
+                              color="error"
+                              onClick={() => log.id && handleDelete(log.id)}
+                            >
+                              <DeleteIcon sx={{ fontSize: rem(16) }} />
+                            </IconButton>
+                          </Tooltip>
+                        </WS.ActionCell>
+                      </WS.Td>
+                    </WS.DataTr>
+                  );
+                })
+              )}
+            </tbody>
+          </WS.Table>
+        </WS.TableContainer>
+      </WS.WorkLogsLayout>
+
+      {/* ── Note Detail Popup ─────────────────────────────────────────────── */}
+      {popupLog && (
+        /* Backdrop — click outside to close */
+        <WS.NotePopupBackdrop onClick={() => setPopupLog(null)}>
+          {/* Card — stop propagation so clicking inside doesn't close */}
+          <WS.NotePopupCard yOffset={popupY} onClick={(e) => e.stopPropagation()}>
+
+            {/* Line 1: start→end time + ✕ close button */}
+            <WS.NotePopupHeader>
+              <WS.NotePopupTimeValue>
+                {formatTime(popupLog.timeIn)} → {formatTime(popupLog.timeOut)}
+              </WS.NotePopupTimeValue>
+              <WS.NotePopupCloseBtn
+                onClick={() => setPopupLog(null)}
+                aria-label="Close"
+              >
+                ✕
+              </WS.NotePopupCloseBtn>
+            </WS.NotePopupHeader>
+
+            {/* Line 2: full note (only rendered when note exists) */}
+            {popupLog.description && (
+              <>
+                <WS.NotePopupDivider />
+                <WS.NotePopupNoteText>{popupLog.description}</WS.NotePopupNoteText>
+              </>
+            )}
+
+          </WS.NotePopupCard>
+        </WS.NotePopupBackdrop>
+      )}
+
+    </WS.WorkLogsOuterLayout>
   );
 };

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
@@ -64,7 +64,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   // ── Data state ──────────────────────────────────────────────────────────────
   const [loadingWorkflow, setLoadingWorkflow] = useState(true);
   const [steps, setSteps] = useState<JobWorkflowStepResponse[]>([]);
-  const [selectedStepId, setSelectedStepId] = useState<number | null>(null);
+  const [selectedStepId, setSelectedStepId] = useState<number | 'all' | null>('all');
   const [visitLogs, setVisitLogs] = useState<StepVisitLogResponse[]>([]);
   const [totalMinutes, setTotalMinutes] = useState(0);
   const [loadingLogs, setLoadingLogs] = useState(false);
@@ -89,7 +89,6 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
         (a, b) => (a.orderIndex || 0) - (b.orderIndex || 0)
       );
       setSteps(sorted);
-      if (sorted.length > 0 && sorted[0].id) setSelectedStepId(sorted[0].id);
     } catch {
       setSteps([]);
     } finally {
@@ -101,16 +100,73 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
     if (!selectedStepId) return;
     try {
       setLoadingLogs(true);
-      const response = await visitLogService.getVisitLogs(selectedStepId);
-      setVisitLogs(response.data.visitLogs || []);
-      setTotalMinutes(response.data.totalWorkedMinutes || 0);
+      if (selectedStepId === 'all') {
+        const promises = steps.map((step) => {
+          if (!step.id) return Promise.resolve({ data: { visitLogs: [], totalWorkedMinutes: 0 } });
+          return visitLogService.getVisitLogs(step.id);
+        });
+        const results = await Promise.all(promises);
+
+        let allLogs: (StepVisitLogResponse & { stepName?: string; stepId?: number })[] = [];
+        let combinedMinutes = 0;
+
+        results.forEach((res, index) => {
+          const stepLogs = res.data.visitLogs || [];
+          const stepName = steps[index].name || `Step ${index + 1}`;
+          const stepId = steps[index].id;
+
+          allLogs = allLogs.concat(
+            stepLogs.map((log) => ({
+              ...log,
+              stepName,
+              stepId,
+            }))
+          );
+          combinedMinutes += res.data.totalWorkedMinutes || 0;
+        });
+
+        // Sort by date/time: newest first.
+        allLogs.sort((a, b) => {
+          const dateA = a.visitDate ? new Date(a.visitDate).getTime() : 0;
+          const dateB = b.visitDate ? new Date(b.visitDate).getTime() : 0;
+          if (dateB !== dateA) return dateB - dateA;
+
+          const timeA = a.timeIn || '';
+          const timeB = b.timeIn || '';
+          if (timeB !== timeA) return timeB.localeCompare(timeA);
+
+          return (b.id || 0) - (a.id || 0);
+        });
+
+        setVisitLogs(allLogs);
+        setTotalMinutes(combinedMinutes);
+      } else {
+        const response = await visitLogService.getVisitLogs(selectedStepId);
+        const stepLogs = response.data.visitLogs || [];
+
+        // Sort by date/time: newest first.
+        const sortedLogs = [...stepLogs].sort((a, b) => {
+          const dateA = a.visitDate ? new Date(a.visitDate).getTime() : 0;
+          const dateB = b.visitDate ? new Date(b.visitDate).getTime() : 0;
+          if (dateB !== dateA) return dateB - dateA;
+
+          const timeA = a.timeIn || '';
+          const timeB = b.timeIn || '';
+          if (timeB !== timeA) return timeB.localeCompare(timeA);
+
+          return (b.id || 0) - (a.id || 0);
+        });
+
+        setVisitLogs(sortedLogs);
+        setTotalMinutes(response.data.totalWorkedMinutes || 0);
+      }
     } catch {
       setVisitLogs([]);
       setTotalMinutes(0);
     } finally {
       setLoadingLogs(false);
     }
-  }, [selectedStepId]);
+  }, [selectedStepId, steps]);
 
   useEffect(() => { fetchWorkflow(); }, [fetchWorkflow]);
   useEffect(() => { fetchVisitLogs(); }, [fetchVisitLogs]);
@@ -176,13 +232,16 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   );
   const openModal = useCallback((editLog?: StepVisitLogResponse) => {
     if (!selectedStepId) return;
+    const logStepId = editLog ? (editLog as any).stepId : null;
+    const resolvedStepId = selectedStepId === 'all' ? logStepId : selectedStepId;
     setGlobalModalOuterProps({
       isOpen: true,
       size: ModalSizes.MEDIUM,
       fieldName: 'addWorkLog',
       children: (
         <AddWorkLogModal
-          stepId={selectedStepId}
+          stepId={resolvedStepId}
+          steps={steps}
           editLog={editLog || null}
           onSuccess={() => {
             resetGlobalModalOuterProps();
@@ -192,7 +251,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
         />
       ),
     });
-  }, [selectedStepId, setGlobalModalOuterProps, resetGlobalModalOuterProps, showSuccess, fetchVisitLogs]);
+  }, [selectedStepId, steps, setGlobalModalOuterProps, resetGlobalModalOuterProps, showSuccess, fetchVisitLogs]);
 
   const handleDelete = useCallback(async (visitLogId: number) => {
     try {
@@ -263,11 +322,25 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
 
         {/* Step circles with connectors */}
         <WS.StepsBubbleList>
+          {/* ALL Bubble */}
+          <WS.StepBubbleItem>
+            <Tooltip title="All Work Logs" placement="right" arrow>
+              <WS.AllStepCircle
+                isActive={selectedStepId === 'all'}
+                stepColor="#101a32"
+                onClick={() => setSelectedStepId('all')}
+              >
+                ALL
+              </WS.AllStepCircle>
+            </Tooltip>
+            {steps.length > 0 && <WS.StepConnector />}
+          </WS.StepBubbleItem>
+
+          {/* Individual steps */}
           {steps.map((step, idx) => {
             const isActive = selectedStepId === step.id;
             return (
               <WS.StepBubbleItem key={step.id}>
-                {idx > 0 && <WS.StepConnector />}
                 <Tooltip
                   title={`${idx + 1}. ${step.name || `Step ${idx + 1}`}`}
                   placement="right"
@@ -281,6 +354,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                     {idx + 1}
                   </WS.StepCircle>
                 </Tooltip>
+                {idx < steps.length - 1 && <WS.StepConnector />}
               </WS.StepBubbleItem>
             );
           })}
@@ -298,7 +372,9 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
             </WS.TimerIconBox>
             <WS.TrackingInfo>
               <WS.TrackingLabel>
-                CURRENTLY TRACKING — {selectedStep?.name?.toUpperCase() || 'STEP'}
+                {selectedStepId === 'all'
+                  ? 'CURRENTLY TRACKING — ALL STEPS'
+                  : `CURRENTLY TRACKING — ${selectedStep?.name?.toUpperCase() || 'STEP'}`}
               </WS.TrackingLabel>
               <WS.TrackingTime>{formatMinutes(totalMinutes)}</WS.TrackingTime>
             </WS.TrackingInfo>
@@ -342,6 +418,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                 <WS.Th>Who</WS.Th>
                 <WS.Th>Start → End</WS.Th>
                 <WS.Th>Duration</WS.Th>
+                {selectedStepId === 'all' && <WS.Th>Step</WS.Th>}
                 <WS.Th>Notes</WS.Th>
                 <WS.Th>Action</WS.Th>
               </WS.Tr>
@@ -349,13 +426,13 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
             <tbody>
               {loadingLogs ? (
                 <tr>
-                  <WS.EmptyStateRow colSpan={6}>
+                  <WS.EmptyStateRow colSpan={selectedStepId === 'all' ? 7 : 6}>
                     <CircularProgress size={20} />
                   </WS.EmptyStateRow>
                 </tr>
               ) : visitLogs.length === 0 ? (
                 <tr>
-                  <WS.EmptyStateRow colSpan={6}>
+                  <WS.EmptyStateRow colSpan={selectedStepId === 'all' ? 7 : 6}>
                     No WorkLog Available
                   </WS.EmptyStateRow>
                 </tr>
@@ -388,6 +465,14 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                       <WS.Td>
                         <WS.DurationText>{formatMinutes(log.workedMinutes)}</WS.DurationText>
                       </WS.Td>
+
+                      {selectedStepId === 'all' && (
+                        <WS.Td>
+                          <WS.StepNameText>
+                            {(log as any).stepName || '-'}
+                          </WS.StepNameText>
+                        </WS.Td>
+                      )}
 
                       {/* Notes — truncated, full text in title attr for native tooltip */}
                       <WS.NotesTd title={log.description || undefined}>

--- a/src/utils/fieldValueHelper.ts
+++ b/src/utils/fieldValueHelper.ts
@@ -1,0 +1,35 @@
+/**
+ * Recursively extracts the raw scalar value from a field value, which can be:
+ * - A primitive value (string, number, boolean)
+ * - An object containing a `value` property: { value: ... }
+ * - A Java/Spring DTO string representation: "{name=customer_name, label=..., value={...}}"
+ */
+export function extractFieldValue(val: any): string {
+  if (val === null || val === undefined) return '';
+
+  let curr = val;
+
+  // 1. Unwrap nested object with 'value' property
+  while (curr && typeof curr === 'object' && 'value' in curr) {
+    curr = curr.value;
+  }
+
+  if (curr === null || curr === undefined) return '';
+
+  // 2. Handle string representation of nested objects or Java toString format
+  if (typeof curr === 'string') {
+    let s = curr.trim();
+    // Iteratively extract 'value=...' if string is in Java DTO format like {name=..., value=...}
+    while (s.startsWith('{') && s.includes('value=')) {
+      const match = s.match(/value=([^,}]+|\{[^}]+\})/);
+      if (match && match[1]) {
+        s = match[1].trim();
+      } else {
+        break;
+      }
+    }
+    return s;
+  }
+
+  return String(curr);
+}


### PR DESCRIPTION
…popups

- Replace the horizontal workflow tab strip with a 3.5rem vertical left rail.
- Represent workflow steps as large step circles with color-coded borders matching the step color.
- Add an expandable 2rem search button to jump to a workflow step by number.
- Add validation to the search input showing a snackbar error if step does not exist.
- Truncate long notes in the table rows and limit row heights to 3.5rem.
- Add a responsive click-to-expand popup card centered on the clicked row containing start/end times and full notes text.
- Consolidate all CSS in JobWorkLogsTab.styles.ts with zero inline styles in the TSX and clean type checks.