### PR TITLE
feat(jobs): drag-to-reorder steps + message edit/delete in Step Activ…

### DIFF
--- a/src/pages/jobs/JobDetailsPage.styles.ts
+++ b/src/pages/jobs/JobDetailsPage.styles.ts
@@ -6,7 +6,6 @@ import ImageIcon from '@mui/icons-material/Image';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import DescriptionIcon from '@mui/icons-material/Description';
 import ReceiptIcon from '@mui/icons-material/Receipt';
-import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 
 export const ContentContainer = styled(Box)(({ theme }) => ({
   padding: theme.spacing(0, 2, 2, 2),

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.styles.ts
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.styles.ts
@@ -256,6 +256,107 @@ export const DateGroupDivider = styled(Box)(({ theme }) => ({
   margin: theme.spacing(2, 0),
 }));
 
+export const MessageBubbleActions = styled(Box)(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.5),
+  flexShrink: 0,
+  marginLeft: theme.spacing(1),
+  opacity: 0.7,
+  transition: 'opacity 0.15s ease',
+  '&:hover': {
+    opacity: 1,
+  },
+}));
+
+interface MessageProps {
+  isMine?: boolean;
+}
+
+// ─── Message hover actions ────────────────────────────────────────────────────
+
+export const MessageActionGroup = styled(Box)(({ theme }) => ({
+  display: 'none',
+  alignItems: 'center',
+  gap: theme.spacing(0.25),
+  alignSelf: 'center',
+  flexShrink: 0,
+}));
+
+export const MessageRowWithActions = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isMine',
+})<MessageProps>(({ isMine }) => ({
+  display: 'flex',
+  flexDirection: isMine ? 'row-reverse' : 'row',
+  alignItems: 'flex-end',
+  gap: rem(10),
+  marginBottom: rem(16),
+  [`&:hover .msg-action-group`]: {
+    display: 'flex',
+  },
+}));
+
+export const MessageEditIconBtn = styled('button')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: rem(26),
+  height: rem(26),
+  borderRadius: rem(6),
+  border: `1px solid ${theme.palette.colors.grey_200}`,
+  backgroundColor: theme.palette.colors.white,
+  cursor: 'pointer',
+  color: theme.palette.text.secondary,
+  transition: 'all 0.15s ease',
+  padding: 0,
+  '&:hover': {
+    backgroundColor: theme.palette.colors.grey_50,
+    color: theme.palette.primary.main,
+    borderColor: theme.palette.primary.main,
+  },
+}));
+
+export const MessageDeleteIconBtn = styled('button')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: rem(26),
+  height: rem(26),
+  borderRadius: rem(6),
+  border: `1px solid ${theme.palette.colors.grey_200}`,
+  backgroundColor: theme.palette.colors.white,
+  cursor: 'pointer',
+  color: theme.palette.error.main,
+  transition: 'all 0.15s ease',
+  padding: 0,
+  '&:hover': {
+    backgroundColor: '#FEF2F2',
+    borderColor: theme.palette.error.main,
+  },
+}));
+
+export const MessageEditInputRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1),
+  alignItems: 'flex-end',
+  marginTop: theme.spacing(0.5),
+}));
+
+export const MessageEditTextField = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    fontSize: rem(13),
+    borderRadius: rem(8),
+    backgroundColor: theme.palette.colors.white,
+    minWidth: rem(200),
+  },
+}));
+
+export const MessageEditActions = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(0.5),
+  flexShrink: 0,
+}));
+
 export const DateGroupLine = styled(Box)(({ theme }) => ({
   flex: 1,
   height: rem(1),
@@ -270,10 +371,6 @@ export const DateGroupText = styled(Typography)(({ theme }) => ({
 }));
 
 // ─── Message bubbles ──────────────────────────────────────────────────────────
-
-interface MessageProps {
-  isMine?: boolean;
-}
 
 export const MessageRow = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'isMine',

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.tsx
@@ -5,6 +5,10 @@ import {
   CircularProgress,
   Typography,
 } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { StandaloneDropdown } from '../../../../../components/UI/Forms/Dropdown';
 import SendIcon from '@mui/icons-material/Send';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
@@ -82,6 +86,12 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
 
   const [selectedPostToStepId, setSelectedPostToStepId] = useState<number | null>(null);
+
+  // ── Edit / delete state ──────────────────────────────────────────────────────
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingContent, setEditingContent] = useState('');
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   // When viewFilter changes: if a specific step is selected, lock target step to viewFilter.
   // When 'all' is selected, use selectedPostToStepId (or default to first step).
@@ -255,6 +265,50 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
     });
   };
 
+  // ── Edit / delete handlers ──────────────────────────────────────────────────
+
+  const startEdit = (item: CombinedTimelineItem) => {
+    setEditingId(item.id ?? null);
+    setEditingContent(item.content || '');
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditingContent('');
+  };
+
+  const saveEdit = async () => {
+    if (!editingId || !editingContent.trim()) return;
+    setSavingEdit(true);
+    try {
+      await stepActivityService.updateComment(editingId, {
+        content: editingContent.trim(),
+        type: postType as StepCommentCreateRequestTypeEnum,
+      });
+      showSuccess('Message updated');
+      cancelEdit();
+      fetchAllTimelines(steps);
+    } catch {
+      showError('Failed to update message');
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleDelete = async (item: CombinedTimelineItem) => {
+    if (!item.id) return;
+    setDeletingId(item.id);
+    try {
+      await stepActivityService.deleteComment(item.id);
+      showSuccess('Message deleted');
+      fetchAllTimelines(steps);
+    } catch {
+      showError('Failed to delete message');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
   // ── Feed renderer ───────────────────────────────────────────────────────────
 
   const renderFeed = () => {
@@ -295,11 +349,14 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
 
       const isMine = !!(currentUserId && item.actorId === currentUserId);
       const isAttachment = item.itemType === 'ATTACHMENT';
+      const isComment = item.itemType === 'COMMENT' || !isAttachment;
+      const isEditing = editingId === item.id;
+      const isDeleting = deletingId === item.id;
       const fileName = extractFileName(item.fileUrl);
       const ts = getTypeStyle(item.discussionType as string);
 
       nodes.push(
-        <SS.MessageRow key={`${item.stepId}-${item.id}-${idx}`} isMine={isMine}>
+        <SS.MessageRowWithActions key={`${item.stepId}-${item.id}-${idx}`} isMine={isMine}>
           <SS.MessageAvatarCircle avatarColor={getAvatarColor(item.actorUsername)}>
             {getInitials(item.actorUsername)}
           </SS.MessageAvatarCircle>
@@ -318,33 +375,88 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
               </SS.MessageTypeBadge>
             </SS.MessageMetaRow>
 
-            <SS.MessageBubble isMine={isMine}>
-              {isAttachment ? (
-                <SS.AttachmentRow>
-                  {getFileIcon(fileName)}
-                  <SS.AttachmentFileName isMine={isMine}>{fileName}</SS.AttachmentFileName>
-                  {item.fileUrl && (
-                    <Tooltip title="Download">
-                      <MuiIconButton
-                        size="small"
-                        onClick={() => window.open(item.fileUrl, '_blank')}
-                        sx={{ color: isMine ? 'rgba(255,255,255,0.8)' : 'text.secondary' }}
-                      >
-                        <DownloadIcon fontSize="small" />
-                      </MuiIconButton>
-                    </Tooltip>
-                  )}
-                </SS.AttachmentRow>
-              ) : (
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: item.content || item.description || '—',
+            {isEditing ? (
+              /* ── Inline edit mode ─────────────────────────────────── */
+              <SS.MessageEditInputRow>
+                <SS.MessageEditTextField
+                  size="small"
+                  value={editingContent}
+                  onChange={e => setEditingContent(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); saveEdit(); }
+                    if (e.key === 'Escape') cancelEdit();
                   }}
+                  multiline
+                  maxRows={4}
+                  autoFocus
+                  fullWidth
                 />
-              )}
-            </SS.MessageBubble>
+                <SS.MessageEditActions>
+                  <Tooltip title="Save (Enter)">
+                    <SS.MessageEditIconBtn onClick={saveEdit} disabled={savingEdit}>
+                      {savingEdit
+                        ? <CircularProgress size={12} />
+                        : <CheckIcon sx={{ fontSize: 14 }} />}
+                    </SS.MessageEditIconBtn>
+                  </Tooltip>
+                  <Tooltip title="Cancel (Esc)">
+                    <SS.MessageEditIconBtn onClick={cancelEdit} disabled={savingEdit}>
+                      <CloseIcon sx={{ fontSize: 14 }} />
+                    </SS.MessageEditIconBtn>
+                  </Tooltip>
+                </SS.MessageEditActions>
+              </SS.MessageEditInputRow>
+            ) : (
+              /* ── Normal display mode ──────────────────────────────── */
+              <SS.MessageBubble isMine={isMine}>
+                {isAttachment ? (
+                  <SS.AttachmentRow>
+                    {getFileIcon(fileName)}
+                    <SS.AttachmentFileName isMine={isMine}>{fileName}</SS.AttachmentFileName>
+                    {item.fileUrl && (
+                      <Tooltip title="Download">
+                        <MuiIconButton
+                          size="small"
+                          onClick={() => window.open(item.fileUrl, '_blank')}
+                          sx={{ color: isMine ? 'rgba(255,255,255,0.8)' : 'text.secondary' }}
+                        >
+                          <DownloadIcon fontSize="small" />
+                        </MuiIconButton>
+                      </Tooltip>
+                    )}
+                  </SS.AttachmentRow>
+                ) : (
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: item.content || item.description || '—',
+                    }}
+                  />
+                )}
+              </SS.MessageBubble>
+            )}
           </SS.MessageContentBox>
-        </SS.MessageRow>
+
+          {/* ── Edit / Delete action buttons (visible on row hover) ── */}
+          {isComment && !isEditing && (
+            <SS.MessageActionGroup className="msg-action-group">
+              <Tooltip title="Edit message">
+                <SS.MessageEditIconBtn onClick={() => startEdit(item)}>
+                  <EditIcon sx={{ fontSize: 13 }} />
+                </SS.MessageEditIconBtn>
+              </Tooltip>
+              <Tooltip title="Delete message">
+                <SS.MessageDeleteIconBtn
+                  onClick={() => handleDelete(item)}
+                  disabled={isDeleting}
+                >
+                  {isDeleting
+                    ? <CircularProgress size={12} color="error" />
+                    : <DeleteIcon sx={{ fontSize: 13 }} />}
+                </SS.MessageDeleteIconBtn>
+              </Tooltip>
+            </SS.MessageActionGroup>
+          )}
+        </SS.MessageRowWithActions>
       );
     });
 

--- a/src/pages/jobs/components/JobWorkflowStages/AddStepModal.styles.ts
+++ b/src/pages/jobs/components/JobWorkflowStages/AddStepModal.styles.ts
@@ -1,0 +1,165 @@
+import { styled } from '@mui/material/styles';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+  Chip,
+} from '@mui/material';
+
+export const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialog-paper': {
+    borderRadius: theme.spacing(1.5),
+    padding: theme.spacing(1),
+    width: '100%',
+    maxWidth: 520,
+    backgroundColor: theme.palette.common.white,
+    boxShadow: '0 12px 32px rgba(0, 0, 0, 0.12)',
+    margin: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      margin: theme.spacing(1),
+      maxWidth: 'calc(100% - 16px)',
+      borderRadius: theme.spacing(1),
+    },
+  },
+}));
+
+export const ModalHeader = styled(DialogTitle)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: theme.spacing(1.5, 2),
+  borderBottom: `1px solid ${theme.palette.grey[200]}`,
+}));
+
+export const ModalTitle = styled(Typography)(({ theme }) => ({
+  fontSize: '1rem',
+  fontWeight: 600,
+  color: theme.palette.text.primary,
+}));
+
+export const CloseButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.grey[500],
+  padding: theme.spacing(0.5),
+  '&:hover': {
+    color: theme.palette.text.primary,
+    backgroundColor: theme.palette.grey[100],
+  },
+}));
+
+export const ModalContent = styled(DialogContent)(({ theme }) => ({
+  padding: theme.spacing(2.5, 2),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+}));
+
+export const FormGroup = styled(Box)(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+}));
+
+export const FormLabel = styled(Typography)(({ theme }) => ({
+  fontSize: '0.8125rem',
+  fontWeight: 600,
+  color: theme.palette.text.secondary,
+}));
+
+export const FormInput = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    fontSize: '0.875rem',
+    borderRadius: theme.spacing(0.75),
+    '& fieldset': {
+      borderColor: theme.palette.grey[300],
+    },
+    '&:hover fieldset': {
+      borderColor: theme.palette.grey[400],
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: theme.palette.primary.main,
+    },
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '8.5px 12px',
+  },
+}));
+
+export const DurationRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1.5),
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+}));
+
+export const DurationFieldGroup = styled(Box)(({ theme }) => ({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+}));
+
+export const DurationInputsBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}));
+
+export const SmallNumberInput = styled(TextField)(({ theme }) => ({
+  width: 70,
+  '& .MuiOutlinedInput-root': {
+    fontSize: '0.8125rem',
+    borderRadius: theme.spacing(0.75),
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '6px 8px',
+    textAlign: 'center',
+  },
+}));
+
+export const UnitLabel = styled(Typography)(({ theme }) => ({
+  fontSize: '0.75rem',
+  color: theme.palette.text.secondary,
+}));
+
+export const ModalActions = styled(DialogActions)(({ theme }) => ({
+  padding: theme.spacing(1.5, 2),
+  borderTop: `1px solid ${theme.palette.grey[200]}`,
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: theme.spacing(1),
+}));
+
+export const CancelButton = styled(Button)(({ theme }) => ({
+  textTransform: 'none',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  color: theme.palette.text.secondary,
+  borderColor: theme.palette.grey[300],
+  '&:hover': {
+    borderColor: theme.palette.grey[400],
+    backgroundColor: theme.palette.grey[50],
+  },
+}));
+
+export const SubmitButton = styled(Button)(({ theme }) => ({
+  textTransform: 'none',
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  borderRadius: theme.spacing(0.75),
+  padding: '6px 16px',
+}));
+
+export const WorkerChip = styled(Chip)(({ theme }) => ({
+  height: 24,
+  fontSize: '0.75rem',
+  fontWeight: 500,
+  borderRadius: theme.spacing(0.5),
+}));

--- a/src/pages/jobs/components/JobWorkflowStages/AddStepModal.tsx
+++ b/src/pages/jobs/components/JobWorkflowStages/AddStepModal.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from 'react';
+import { Autocomplete } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import type { WorkerResponse } from '../../../../services/api';
+import type { JobWorkflowStepCreateRequest } from '../../../../../workflow-api';
+import * as S from './AddStepModal.styles';
+
+interface AddStepModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: JobWorkflowStepCreateRequest) => Promise<void>;
+  allWorkers: WorkerResponse[];
+  nextOrderIndex: number;
+}
+
+export const AddStepModal: React.FC<AddStepModalProps> = ({
+  open,
+  onClose,
+  onSubmit,
+  allWorkers,
+  nextOrderIndex,
+}) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [expectedDays, setExpectedDays] = useState<number | string>('');
+  const [expectedHours, setExpectedHours] = useState<number | string>('');
+  const [maxDays, setMaxDays] = useState<number | string>('');
+  const [maxHours, setMaxHours] = useState<number | string>('');
+  const [selectedWorkers, setSelectedWorkers] = useState<WorkerResponse[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const resetForm = () => {
+    setName('');
+    setDescription('');
+    setExpectedDays('');
+    setExpectedHours('');
+    setMaxDays('');
+    setMaxHours('');
+    setSelectedWorkers([]);
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const expectedMinutes = (Number(expectedDays) || 0) * 24 * 60 + (Number(expectedHours) || 0) * 60;
+    const maxMinutes = (Number(maxDays) || 0) * 24 * 60 + (Number(maxHours) || 0) * 60;
+    const workerIds = selectedWorkers.map((w) => w.id!).filter(Boolean);
+
+    const payload: JobWorkflowStepCreateRequest = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      orderIndex: nextOrderIndex,
+      assignedWorkerIds: workerIds.length > 0 ? (new Set(workerIds) as any) : undefined,
+      expectedDurationMinutes: expectedMinutes > 0 ? expectedMinutes : undefined,
+      maximumDurationMinutes: maxMinutes > 0 ? maxMinutes : undefined,
+    };
+
+    try {
+      setSubmitting(true);
+      await onSubmit(payload);
+      resetForm();
+      onClose();
+    } catch (err) {
+      console.error('Error submitting add step:', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <S.StyledDialog open={open} onClose={handleClose} fullWidth>
+      <form onSubmit={handleSubmit}>
+        <S.ModalHeader>
+          <S.ModalTitle>Add Step to Job Workflow</S.ModalTitle>
+          <S.CloseButton size="small" onClick={handleClose} aria-label="Close add step modal">
+            <CloseIcon fontSize="small" />
+          </S.CloseButton>
+        </S.ModalHeader>
+
+        <S.ModalContent>
+          {/* Step Name */}
+          <S.FormGroup>
+            <S.FormLabel>Step Name *</S.FormLabel>
+            <S.FormInput
+              fullWidth
+              size="small"
+              placeholder="e.g., Initial Site Inspection"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              autoFocus
+            />
+          </S.FormGroup>
+
+          {/* Description */}
+          <S.FormGroup>
+            <S.FormLabel>Description</S.FormLabel>
+            <S.FormInput
+              fullWidth
+              multiline
+              rows={3}
+              size="small"
+              placeholder="Add details or instructions for this step..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </S.FormGroup>
+
+          {/* Durations */}
+          <S.DurationRow>
+            {/* Expected duration */}
+            <S.DurationFieldGroup>
+              <S.FormLabel>Expected Duration</S.FormLabel>
+              <S.DurationInputsBox>
+                <S.SmallNumberInput
+                  type="number"
+                  size="small"
+                  placeholder="0"
+                  value={expectedDays}
+                  onChange={(e) => setExpectedDays(e.target.value)}
+                />
+                <S.UnitLabel>days</S.UnitLabel>
+                <S.SmallNumberInput
+                  type="number"
+                  size="small"
+                  placeholder="0"
+                  value={expectedHours}
+                  onChange={(e) => setExpectedHours(e.target.value)}
+                />
+                <S.UnitLabel>hrs</S.UnitLabel>
+              </S.DurationInputsBox>
+            </S.DurationFieldGroup>
+
+            {/* Maximum duration */}
+            <S.DurationFieldGroup>
+              <S.FormLabel>Maximum Duration</S.FormLabel>
+              <S.DurationInputsBox>
+                <S.SmallNumberInput
+                  type="number"
+                  size="small"
+                  placeholder="0"
+                  value={maxDays}
+                  onChange={(e) => setMaxDays(e.target.value)}
+                />
+                <S.UnitLabel>days</S.UnitLabel>
+                <S.SmallNumberInput
+                  type="number"
+                  size="small"
+                  placeholder="0"
+                  value={maxHours}
+                  onChange={(e) => setMaxHours(e.target.value)}
+                />
+                <S.UnitLabel>hrs</S.UnitLabel>
+              </S.DurationInputsBox>
+            </S.DurationFieldGroup>
+          </S.DurationRow>
+
+          {/* Assignees */}
+          <S.FormGroup>
+            <S.FormLabel>Assign Workers</S.FormLabel>
+            <Autocomplete
+              multiple
+              fullWidth
+              size="small"
+              options={allWorkers}
+              value={selectedWorkers}
+              getOptionLabel={(option) => option.name || ''}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              onChange={(_, newValue) => setSelectedWorkers(newValue)}
+              disablePortal
+              disableCloseOnSelect
+              renderInput={(params) => (
+                <S.FormInput
+                  {...params}
+                  placeholder={selectedWorkers.length === 0 ? 'Select workers...' : ''}
+                />
+              )}
+              renderTags={(value, getTagProps) =>
+                value.map((option, index) => {
+                  const tagProps = getTagProps({ index });
+                  return (
+                    <S.WorkerChip
+                      {...tagProps}
+                      key={tagProps.key}
+                      label={option.name}
+                      size="small"
+                    />
+                  );
+                })
+              }
+            />
+          </S.FormGroup>
+        </S.ModalContent>
+
+        <S.ModalActions>
+          <S.CancelButton variant="outlined" onClick={handleClose} disabled={submitting}>
+            Cancel
+          </S.CancelButton>
+          <S.SubmitButton type="submit" variant="contained" disabled={submitting || !name.trim()}>
+            {submitting ? 'Adding...' : 'Add Step'}
+          </S.SubmitButton>
+        </S.ModalActions>
+      </form>
+    </S.StyledDialog>
+  );
+};

--- a/src/pages/jobs/components/JobWorkflowStages/JobWorkflowStages.styles.ts
+++ b/src/pages/jobs/components/JobWorkflowStages/JobWorkflowStages.styles.ts
@@ -1,61 +1,174 @@
-import type { SxProps, Theme } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { Box, Chip, Button, IconButton, TextField, FormControl, Select } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import AddIcon from '@mui/icons-material/Add';
+import ImageIcon from '@mui/icons-material/Image';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import DescriptionIcon from '@mui/icons-material/Description';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
 
-export const styles = {
-  // ─── Loading / Empty states ───────────────────────────────────────────────
+// ─── Containers & Layout ───────────────────────────────────────────────────
 
-  loadingContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    py: 4,
-  } as SxProps<Theme>,
+export const TimelineListWrapper = styled(Box)(({ theme }) => ({
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(2),
+  overflowY: 'auto',
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0),
+  [theme.breakpoints.down('sm')]: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
+}));
 
-  // ─── Timeline list wrapper ────────────────────────────────────────────────
+export const LoadingContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: theme.spacing(4),
+  paddingBottom: theme.spacing(4),
+}));
 
-  timelineList: {
-    px: 2,
-    py: 1,
-    overflowY: 'auto',
-    flex: 1,
-  } as SxProps<Theme>,
+export const EmptyStateContainer = styled(Box)(({ theme }) => ({
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  paddingTop: theme.spacing(3),
+  paddingBottom: theme.spacing(3),
+}));
 
-  // ─── Individual step row ──────────────────────────────────────────────────
+// ─── Step Item Row & Rail ──────────────────────────────────────────────────
 
-  stepRow: {
-    display: 'flex',
-    position: 'relative',
-  } as SxProps<Theme>,
+export const StepRowContainer = styled(Box)(() => ({
+  display: 'flex',
+  position: 'relative',
+  transition: 'background-color 0.15s ease',
+}));
 
-  // ─── Vertical connector line between nodes ────────────────────────────────
+export const TimelineLineCompleted = styled(Box)(() => ({
+  position: 'absolute',
+  left: 13,
+  top: 28,
+  bottom: 0,
+  width: 2,
+  backgroundColor: '#4CAF50',
+}));
 
-  timelineLineCompleted: {
-    position: 'absolute',
-    left: 13,
-    top: 28,
-    bottom: 0,
-    width: 2,
-    backgroundColor: '#4CAF50',
-  } as SxProps<Theme>,
+export const TimelineLinePending = styled(Box)(() => ({
+  position: 'absolute',
+  left: 13,
+  top: 28,
+  bottom: 0,
+  width: 2,
+  backgroundColor: '#E0E0E0',
+}));
 
-  timelineLinePending: {
-    position: 'absolute',
-    left: 13,
-    top: 28,
-    bottom: 0,
-    width: 2,
-    backgroundColor: '#E0E0E0',
-  } as SxProps<Theme>,
+export const StepDragGrip = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: theme.palette.grey[400],
+  cursor: 'grab',
+  paddingRight: theme.spacing(0.5),
+  '&:hover': {
+    color: theme.palette.grey[700],
+  },
+  '&:active': {
+    cursor: 'grabbing',
+  },
+}));
 
-  // ─── Circular timeline node ───────────────────────────────────────────────
+export const ReorderDragRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.5),
+  width: '100%',
+  padding: theme.spacing(1.25, 1.5),
+  marginBottom: theme.spacing(0.75),
+  borderRadius: theme.spacing(1),
+  border: `1px solid ${theme.palette.divider}`,
+  backgroundColor: '#FFFFFF',
+  cursor: 'grab',
+  userSelect: 'none',
+  boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
+  transition: 'box-shadow 0.15s ease, background-color 0.15s ease',
+  '&:hover': {
+    backgroundColor: '#F5F8FF',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.10)',
+  },
+  '&:active': {
+    cursor: 'grabbing',
+    backgroundColor: '#EEF3FF',
+  },
+}));
 
-  timelineNodeBase: {
+export const ReorderDragIndex = styled('span')(({ theme }) => ({
+  minWidth: 22,
+  height: 22,
+  borderRadius: '50%',
+  backgroundColor: theme.palette.primary.main,
+  color: '#FFFFFF',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  flexShrink: 0,
+}));
+
+export const ReorderDragTitle = styled('span')(({ theme }) => ({
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  color: theme.palette.text.primary,
+  flex: 1,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+}));
+
+export const DragIcon = styled(DragIndicatorIcon)(() => ({
+  fontSize: 18,
+}));
+
+// ─── Timeline Nodes ────────────────────────────────────────────────────────
+
+interface NodeProps {
+  statusVariant?: 'completed' | 'inProgress' | 'delayed' | 'default';
+}
+
+export const TimelineNode = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'statusVariant',
+})<NodeProps>(({ statusVariant }) => {
+  let bg = '#E0E0E0';
+  let color = '#666';
+
+  if (statusVariant === 'completed' || statusVariant === 'inProgress') {
+    bg = '#4CAF50';
+    color = '#FFFFFF';
+  } else if (statusVariant === 'delayed') {
+    bg = '#F44336';
+    color = '#FFFFFF';
+  }
+
+  return {
     width: 28,
     height: 28,
     borderRadius: '50%',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: '#666',
+    backgroundColor: bg,
+    color,
     fontSize: 12,
     fontWeight: 600,
     flexShrink: 0,
@@ -66,268 +179,372 @@ export const styles = {
     '&:hover': {
       transform: 'scale(1.1)',
     },
-  } as SxProps<Theme>,
+  };
+});
 
-  timelineNodeCompleted: {
-    width: 28,
-    height: 28,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#4CAF50',
-    color: 'white',
-    fontSize: 12,
+// ─── Icons ────────────────────────────────────────────────────────────────
+
+export const NodeIconCheck = styled(CheckIcon)(() => ({
+  fontSize: 16,
+}));
+
+export const NodeIconPlay = styled(PlayArrowIcon)(() => ({
+  fontSize: 16,
+}));
+
+export const NodeIconClose = styled(CloseIcon)(() => ({
+  fontSize: 16,
+}));
+
+export const SmallIconEdit = styled(EditIcon)(() => ({
+  fontSize: 14,
+}));
+
+export const SmallIconSave = styled(SaveIcon)(() => ({
+  fontSize: 14,
+}));
+
+export const SmallIconDelete = styled(DeleteIcon)(() => ({
+  fontSize: 14,
+}));
+
+export const SmallIconClose = styled(CloseIcon)(() => ({
+  fontSize: 14,
+}));
+
+export const SmallIconAdd = styled(AddIcon)(() => ({
+  fontSize: 16,
+  marginRight: 4,
+}));
+
+// ─── Step Content & Header ─────────────────────────────────────────────────
+
+export const StepContentBox = styled(Box)(({ theme }) => ({
+  marginLeft: theme.spacing(1.5),
+  flex: 1,
+  paddingBottom: theme.spacing(2),
+  minWidth: 0,
+  [theme.breakpoints.down('sm')]: {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+export const StepTitleHeaderRow = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+}));
+
+export const StepTitleEditWrapper = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  flex: 1,
+}));
+
+export const StepTitleIndexSpan = styled('span')(({ theme }) => ({
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  color: theme.palette.text.primary,
+}));
+
+export const StepTitleTextField = styled(TextField)(() => ({
+  flex: 1,
+  '& .MuiOutlinedInput-root': {
+    fontSize: 14,
     fontWeight: 600,
-    flexShrink: 0,
-    cursor: 'pointer',
-    position: 'relative',
-    zIndex: 1,
-    transition: 'transform 0.2s',
-    '&:hover': {
-      transform: 'scale(1.1)',
-    },
-  } as SxProps<Theme>,
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '2px 6px',
+  },
+}));
 
-  timelineNodeInProgress: {
-    width: 28,
-    height: 28,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#4CAF50',
-    color: 'white',
+export const DraggableTitleWrapper = styled(Box)<{ isreordering?: string }>(({ theme, isreordering }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.5),
+  flex: 1,
+  cursor: isreordering === 'true' ? 'grab' : 'pointer',
+  userSelect: isreordering === 'true' ? 'none' : 'auto',
+  '&:active': {
+    cursor: isreordering === 'true' ? 'grabbing' : 'pointer',
+  },
+}));
+
+export const StepActionButtonsBox = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2px',
+}));
+
+export const ActionIconButton = styled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.5),
+  color: theme.palette.grey[600],
+  '&:hover': {
+    backgroundColor: theme.palette.grey[100],
+    color: theme.palette.text.primary,
+  },
+}));
+
+export const DeleteActionButton = styled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.5),
+  color: theme.palette.error.main,
+  '&:hover': {
+    backgroundColor: theme.palette.error.light,
+    color: theme.palette.error.dark,
+  },
+}));
+
+export const StepDescriptionText = styled(Box)(({ theme }) => ({
+  fontSize: 12,
+  color: theme.palette.grey[600],
+  marginBottom: theme.spacing(1),
+  wordBreak: 'break-word',
+}));
+
+export const ChipsRowBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(0.5),
+  flexWrap: 'wrap',
+  cursor: 'pointer',
+}));
+
+export const StyledStatusChip = styled(Chip)<{ chipbg?: string; chipcolor?: string }>(({ chipbg, chipcolor }) => ({
+  height: 24,
+  fontSize: 11,
+  fontWeight: 600,
+  borderRadius: '4px',
+  backgroundColor: chipbg || '#F5F5F5',
+  color: chipcolor || '#616161',
+}));
+
+export const AssignedYouChip = styled(Chip)(() => ({
+  height: 24,
+  fontSize: 11,
+  fontWeight: 600,
+  backgroundColor: '#F5F5F5',
+  color: '#616161',
+  borderRadius: '4px',
+}));
+
+// ─── Expanded Panel ────────────────────────────────────────────────────────
+
+export const ExpandedPanelBox = styled(Box)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  paddingTop: theme.spacing(2),
+  borderTop: `1px solid ${theme.palette.grey[200]}`,
+}));
+
+export const DurationEditRowBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
+}));
+
+export const DurationUnitText = styled('span')(({ theme }) => ({
+  fontSize: 12,
+  color: theme.palette.text.secondary,
+}));
+
+export const DurationValueText = styled('span')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 500,
+  color: theme.palette.text.primary,
+}));
+
+export const DurationNumberInput = styled(TextField)(() => ({
+  width: 50,
+  '& .MuiOutlinedInput-input': {
+    padding: '2px 4px',
     fontSize: 12,
+    textAlign: 'center',
+  },
+}));
+
+export const DurationValueBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}));
+
+export const StatusSelectControl = styled(FormControl)(() => ({
+  minWidth: 140,
+}));
+
+export const StatusSelectComponent = styled(Select)(() => ({
+  fontSize: 12,
+  '& .MuiSelect-select': {
+    paddingTop: 4,
+    paddingBottom: 4,
+  },
+}));
+
+export const StatusMenuItemChip = styled(Chip)<{ chipbg?: string; chipcolor?: string }>(({ chipbg, chipcolor }) => ({
+  height: 20,
+  fontSize: 10,
+  fontWeight: 600,
+  backgroundColor: chipbg,
+  color: chipcolor,
+}));
+
+export const DateValueText = styled('span')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 500,
+  color: theme.palette.text.primary,
+}));
+
+// ─── Header Controls & Buttons (White Background) ──────────────────────────
+
+export const HeaderActionsBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}));
+
+export const ReOrderWhiteButton = styled(Button)<{ isreordering?: string }>(({ theme, isreordering }) => ({
+  textTransform: 'none',
+  fontSize: '0.8125rem',
+  fontWeight: 600,
+  borderRadius: theme.spacing(0.75),
+  padding: '4px 12px',
+  backgroundColor: '#FFFFFF',
+  borderColor: isreordering === 'true' ? theme.palette.primary.main : theme.palette.grey[300],
+  color: isreordering === 'true' ? theme.palette.primary.main : theme.palette.text.primary,
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.05)',
+  '&:hover': {
+    backgroundColor: '#FAFAFA',
+    borderColor: theme.palette.primary.main,
+  },
+}));
+
+export const AddStepWhiteButton = styled(Button)(({ theme }) => ({
+  textTransform: 'none',
+  fontSize: '0.8125rem',
+  fontWeight: 600,
+  borderRadius: theme.spacing(0.75),
+  padding: '4px 12px',
+  backgroundColor: '#FFFFFF',
+  borderColor: theme.palette.grey[300],
+  color: theme.palette.primary.main,
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.05)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(0.5),
+  '&:hover': {
+    backgroundColor: '#F8FAFC',
+    borderColor: theme.palette.primary.main,
+  },
+}));
+
+export const WorkflowNameInput = styled(TextField)(() => ({
+  '& .MuiOutlinedInput-root': {
+    fontSize: 14,
     fontWeight: 600,
-    flexShrink: 0,
-    cursor: 'pointer',
-    position: 'relative',
-    zIndex: 1,
-    transition: 'transform 0.2s',
-    '&:hover': {
-      transform: 'scale(1.1)',
-    },
-  } as SxProps<Theme>,
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '2px 6px',
+  },
+}));
 
-  timelineNodeDelayed: {
-    width: 28,
-    height: 28,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#F44336',
-    color: 'white',
+export const WorkerAvatarBox = styled(Box)(({ theme }) => ({
+  width: 24,
+  height: 24,
+  borderRadius: '50%',
+  backgroundColor: theme.palette.primary.main,
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 10,
+  fontWeight: 600,
+}));
+
+export const WorkerAvatarsRow = styled('span')(({ theme }) => ({
+  display: 'inline-flex',
+  gap: theme.spacing(0.5),
+  marginLeft: theme.spacing(1),
+}));
+
+export const HeaderButtonsRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(0.5),
+}));
+
+// ─── Add Step Button Card (At bottom of timeline) ───────────────────────────
+
+export const AddStepCardButton = styled(Button)(({ theme }) => ({
+  textTransform: 'none',
+  width: '100%',
+  marginTop: theme.spacing(1.5),
+  padding: theme.spacing(1, 2),
+  borderRadius: theme.spacing(1),
+  border: `1px solid ${theme.palette.primary.main}`,
+  backgroundColor: '#FFFFFF',
+  color: theme.palette.primary.main,
+  fontWeight: 600,
+  fontSize: '0.875rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.04)',
+  '&:hover': {
+    backgroundColor: '#F0F7FF',
+    borderColor: theme.palette.primary.dark,
+  },
+}));
+
+// ─── Notes & Event Notes ───────────────────────────────────────────────────
+
+export const NotesTextField = styled(TextField)(() => ({
+  '& .MuiOutlinedInput-root': {
     fontSize: 12,
-    fontWeight: 600,
-    flexShrink: 0,
-    cursor: 'pointer',
-    position: 'relative',
-    zIndex: 1,
-    transition: 'transform 0.2s',
-    '&:hover': {
-      transform: 'scale(1.1)',
-    },
-  } as SxProps<Theme>,
+  },
+}));
 
-  timelineNodeDefault: {
-    width: 28,
-    height: 28,
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#E0E0E0',
-    color: '#666',
-    fontSize: 12,
-    fontWeight: 600,
-    flexShrink: 0,
-    cursor: 'pointer',
-    position: 'relative',
-    zIndex: 1,
-    transition: 'transform 0.2s',
-    '&:hover': {
-      transform: 'scale(1.1)',
-    },
-  } as SxProps<Theme>,
+export const NotesEditButtonsRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1),
+}));
 
-  // ─── Step content area ────────────────────────────────────────────────────
+// ─── File Icons & Hidden File Input ─────────────────────────────────────────
 
-  stepContent: {
-    ml: 1.5,
-    flex: 1,
-    pb: 2,
-    minWidth: 0,
-  } as SxProps<Theme>,
+export const StyledImageIcon = styled(ImageIcon)(({ theme }) => ({
+  fontSize: 18,
+  color: theme.palette.success.main,
+}));
 
-  stepDescription: {
-    fontSize: 12,
-    color: '#888',
-    mb: 1,
-  } as SxProps<Theme>,
+export const StyledPdfIcon = styled(PictureAsPdfIcon)(({ theme }) => ({
+  fontSize: 18,
+  color: theme.palette.error.main,
+}));
 
-  // ─── Status + chips row (clickable to toggle expand) ─────────────────────
+export const StyledDocIcon = styled(DescriptionIcon)(({ theme }) => ({
+  fontSize: 18,
+  color: theme.palette.info.main,
+}));
 
-  chipsRow: {
-    display: 'flex',
-    gap: 0.5,
-    flexWrap: 'wrap',
-    cursor: 'pointer',
-  } as SxProps<Theme>,
+export const StyledGenericFileIcon = styled(InsertDriveFileIcon)(({ theme }) => ({
+  fontSize: 18,
+  color: theme.palette.text.secondary,
+}));
 
-  statusChip: {
-    height: 24,
-    fontSize: 11,
-    fontWeight: 600,
-    borderRadius: '4px',
-  } as SxProps<Theme>,
+export const StyledAttachFileIcon = styled(AttachFileIcon)(({ theme }) => ({
+  fontSize: 24,
+  color: theme.palette.text.secondary,
+  marginBottom: theme.spacing(0.5),
+}));
 
-  assignedChip: {
-    height: 24,
-    fontSize: 11,
-    fontWeight: 600,
-    backgroundColor: '#F5F5F5',
-    color: '#616161',
-    borderRadius: '4px',
-  } as SxProps<Theme>,
+export const StyledAttachFileSmallIcon = styled(AttachFileIcon)(() => ({
+  fontSize: 14,
+}));
 
-  // ─── Expanded details panel ───────────────────────────────────────────────
+export const HiddenFileInput = styled('input')(() => ({
+  display: 'none',
+}));
 
-  expandedPanel: {
-    mt: 2,
-    pt: 2,
-    borderTop: '1px solid #eee',
-  } as SxProps<Theme>,
+// ─── Legacy style object export for backwards compatibility ────────────────
 
-  // ─── Duration edit row ────────────────────────────────────────────────────
-
-  durationEditRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 1,
-    flexWrap: 'wrap',
-    justifyContent: 'flex-end',
-  } as SxProps<Theme>,
-
-  durationLabel: {
-    fontSize: 12,
-  } as React.CSSProperties,
-
-  durationValueText: {
-    fontSize: 12,
-    fontWeight: 500,
-    color: '#333',
-  } as React.CSSProperties,
-
-  durationTextField: {
-    width: 50,
-    '& .MuiOutlinedInput-input': {
-      py: 0.25,
-      px: 0.5,
-      fontSize: 12,
-      textAlign: 'center',
-    },
-  } as SxProps<Theme>,
-
-  durationEditIconButton: {
-    p: 0.25,
-  } as SxProps<Theme>,
-
-  durationValueBox: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 1,
-  } as SxProps<Theme>,
-
-  // ─── Status select ────────────────────────────────────────────────────────
-
-  statusSelect: {
-    minWidth: 140,
-  } as SxProps<Theme>,
-
-  statusSelectInput: {
-    fontSize: 12,
-    '& .MuiSelect-select': {
-      py: 0.5,
-    },
-  } as SxProps<Theme>,
-
-  statusMenuItemChip: {
-    height: 20,
-    fontSize: 10,
-    fontWeight: 600,
-  } as SxProps<Theme>,
-
-  // ─── Dates ────────────────────────────────────────────────────────────────
-
-  dateValueText: {
-    fontSize: 12,
-    fontWeight: 500,
-    color: '#333',
-  } as React.CSSProperties,
-
-  // ─── Workflow name header ─────────────────────────────────────────────────
-
-  workflowNameTextField: {
-    '& .MuiOutlinedInput-root': {
-      fontSize: 14,
-      fontWeight: 600,
-    },
-    '& .MuiOutlinedInput-input': {
-      py: 0.5,
-      px: 1,
-    },
-  } as SxProps<Theme>,
-
-  workflowNameAvatarRow: {
-    display: 'inline-flex',
-    gap: 0.5,
-    ml: 1,
-  } as SxProps<Theme>,
-
-  workerAvatar: {
-    width: 24,
-    height: 24,
-    borderRadius: '50%',
-    backgroundColor: 'primary.main',
-    color: 'white',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: 10,
-    fontWeight: 600,
-  } as SxProps<Theme>,
-
-  workflowNameEditButtons: {
-    display: 'flex',
-    gap: 0.5,
-  } as SxProps<Theme>,
-
-  // ─── Step name inline edit ────────────────────────────────────────────────
-
-  stepNameTextField: {
-    flex: 1,
-    '& .MuiOutlinedInput-root': {
-      fontSize: 14,
-      fontWeight: 600,
-    },
-    '& .MuiOutlinedInput-input': {
-      py: 0.25,
-      px: 0.5,
-    },
-  } as SxProps<Theme>,
-
-  // ─── Notes / event notes ──────────────────────────────────────────────────
-
-  notesTextField: {
-    '& .MuiOutlinedInput-root': {
-      fontSize: 12,
-    },
-  } as SxProps<Theme>,
-
-  notesEditButtonRow: {
-    display: 'flex',
-    gap: 1,
-  } as SxProps<Theme>,
-};
+export const styles = {};

--- a/src/pages/jobs/components/JobWorkflowStages/JobWorkflowStages.tsx
+++ b/src/pages/jobs/components/JobWorkflowStages/JobWorkflowStages.tsx
@@ -1,34 +1,45 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import {
   CircularProgress,
-  Box,
   IconButton,
   TextField,
-  Select,
   MenuItem,
-  FormControl,
-  Chip,
   Collapse,
   Autocomplete,
   Tooltip,
 } from '@mui/material';
-
-import type { SelectChangeEvent } from '@mui/material';
-import CheckIcon from '@mui/icons-material/Check';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import CloseIcon from '@mui/icons-material/Close';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
+import CloseIcon from '@mui/icons-material/Close';
 import TimerIcon from '@mui/icons-material/Timer';
+
 import type { JobResponse, WorkerResponse, WorkflowResponse } from '../../../../services/api';
 import { jobWorkflowService, workerService, workflowService } from '../../../../services/api';
 import type { JobWorkflowResponse, JobWorkflowStepResponse } from '../../../../services/api';
-import { JobWorkflowStepResponseStatusEnum, JobWorkflowStepResponseSlaStatusEnum } from '../../../../../workflow-api';
+import { JobWorkflowStepResponseStatusEnum, JobWorkflowStepResponseSlaStatusEnum, type JobWorkflowStepCreateRequest } from '../../../../../workflow-api';
 import { useSnackbar } from '../../../../contexts/SnackbarContext';
 import { StepCommentsSection } from './StepCommentsSection';
 import { StepAttachmentsSection } from './StepAttachmentsSection';
-import * as S from '../../JobDetailsPage.styles';
-import { styles } from './JobWorkflowStages.styles';
+import { AddStepModal } from './AddStepModal';
+import * as SPage from '../../JobDetailsPage.styles';
+import * as S from './JobWorkflowStages.styles';
 
 // ─── SLA Timer ────────────────────────────────────────────────────────────────
 
@@ -82,7 +93,7 @@ const SlaTimer: React.FC<{ step: JobWorkflowStepResponse }> = ({ step }) => {
 
   return (
     <Tooltip title="Time remaining until SLA breach" placement="top">
-      <S.SlaTimerChip
+      <SPage.SlaTimerChip
         icon={<TimerIcon />}
         label={label}
         size="small"
@@ -92,81 +103,511 @@ const SlaTimer: React.FC<{ step: JobWorkflowStepResponse }> = ({ step }) => {
   );
 };
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface JobWorkflowStagesProps {
-  job: JobResponse;
-  onStepUpdate?: () => void;
-}
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const getStatusInfo = (status?: string) => {
   switch (status) {
     case JobWorkflowStepResponseStatusEnum.Completed:
-      return { label: 'COMPLETED', isCompleted: true,  isInProgress: false, isDelayed: false, chipBg: '#E8F5E9', chipColor: '#2E7D32' };
+      return { label: 'COMPLETED', isCompleted: true, isInProgress: false, isDelayed: false, chipBg: '#E8F5E9', chipColor: '#2E7D32', variant: 'completed' as const };
     case JobWorkflowStepResponseStatusEnum.Started:
-      return { label: 'STARTED',   isCompleted: false, isInProgress: true,  isDelayed: false, chipBg: '#E3F2FD', chipColor: '#1565C0' };
     case JobWorkflowStepResponseStatusEnum.Ongoing:
-      return { label: 'ONGOING',   isCompleted: false, isInProgress: true,  isDelayed: false, chipBg: '#E3F2FD', chipColor: '#1565C0' };
+      return { label: status === JobWorkflowStepResponseStatusEnum.Started ? 'STARTED' : 'ONGOING', isCompleted: false, isInProgress: true, isDelayed: false, chipBg: '#E3F2FD', chipColor: '#1565C0', variant: 'inProgress' as const };
     case JobWorkflowStepResponseStatusEnum.Pending:
-      return { label: 'PENDING',   isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#FFF8E1', chipColor: '#F9A825' };
+      return { label: 'PENDING', isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#FFF8E1', chipColor: '#F9A825', variant: 'default' as const };
     case JobWorkflowStepResponseStatusEnum.Skipped:
-      return { label: 'SKIPPED',   isCompleted: false, isInProgress: false, isDelayed: true,  chipBg: '#FFEBEE', chipColor: '#C62828' };
+      return { label: 'SKIPPED', isCompleted: false, isInProgress: false, isDelayed: true, chipBg: '#FFEBEE', chipColor: '#C62828', variant: 'delayed' as const };
     case JobWorkflowStepResponseStatusEnum.Initiated:
-      return { label: 'INITIATED', isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#F3E5F5', chipColor: '#7B1FA2' };
+      return { label: 'INITIATED', isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#F3E5F5', chipColor: '#7B1FA2', variant: 'default' as const };
     case JobWorkflowStepResponseStatusEnum.NotStarted:
     default:
-      return { label: 'NOT_STARTED', isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#F5F5F5', chipColor: '#616161' };
+      return { label: 'NOT_STARTED', isCompleted: false, isInProgress: false, isDelayed: false, chipBg: '#F5F5F5', chipColor: '#616161', variant: 'default' as const };
   }
 };
 
 const formatStepDate = (isoString?: string) => {
   if (!isoString) return '';
   const date = new Date(isoString);
-  const day     = date.getDate().toString().padStart(2, '0');
-  const month   = (date.getMonth() + 1).toString().padStart(2, '0');
-  const year    = date.getFullYear();
-  let   hours   = date.getHours();
+  const day = date.getDate().toString().padStart(2, '0');
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const year = date.getFullYear();
+  let hours = date.getHours();
   const minutes = date.getMinutes().toString().padStart(2, '0');
-  const ampm    = hours >= 12 ? 'PM' : 'AM';
+  const ampm = hours >= 12 ? 'PM' : 'AM';
   hours = hours % 12 || 12;
   return `${day}/${month}/${year} (${hours.toString().padStart(2, '0')}:${minutes}${ampm})`;
 };
 
 const formatDuration = (minutes?: number) => {
   if (minutes == null) return '';
-  const days  = Math.floor(minutes / (24 * 60));
+  const days = Math.floor(minutes / (24 * 60));
   const hours = Math.floor((minutes % (24 * 60)) / 60);
   const parts: string[] = [];
-  if (days  > 0) parts.push(`${days} day${days   > 1 ? 's' : ''}`);
+  if (days > 0) parts.push(`${days} day${days > 1 ? 's' : ''}`);
   if (hours > 0) parts.push(`${hours} hour${hours > 1 ? 's' : ''}`);
   return parts.length > 0 ? parts.join(' ') : '0 hours';
 };
 
-// ─── Component ────────────────────────────────────────────────────────────────
+// ─── Interfaces ───────────────────────────────────────────────────────────────
+
+interface JobWorkflowStagesProps {
+  job: JobResponse;
+  onStepUpdate?: () => void;
+}
+
+interface SortableStepRowProps {
+  step: JobWorkflowStepResponse;
+  index: number;
+  isLast: boolean;
+  isExpanded: boolean;
+  isReordering: boolean;
+  editingStepNameId: number | null;
+  stepNameValue: string;
+  updatingStep: number | null;
+  editingNotes: string;
+  editingStepId: number | null;
+  savingNotes: boolean;
+  editingDurationStepId: number | null;
+  editingDurationType: 'expected' | 'maximum' | null;
+  editDays: number | string;
+  editHours: number | string;
+  workers: Map<number, WorkerResponse>;
+  allWorkers: WorkerResponse[];
+  onToggleStep: (stepId: number) => void;
+  onStartEditStepName: (step: JobWorkflowStepResponse, e: React.MouseEvent) => void;
+  onCancelEditStepName: (e: React.MouseEvent) => void;
+  onSaveStepName: (step: JobWorkflowStepResponse, e: React.MouseEvent) => void;
+  onDeleteStep: (step: JobWorkflowStepResponse, e: React.MouseEvent) => void;
+  onStatusChange: (step: JobWorkflowStepResponse, newStatus: string) => void;
+  onAssignedChange: (step: JobWorkflowStepResponse, workerIds: number[]) => void;
+  onEditNotes: (step: JobWorkflowStepResponse, e: React.MouseEvent) => void;
+  onCancelEditNotes: () => void;
+  onSaveNotes: (step: JobWorkflowStepResponse) => void;
+  onEditDuration: (step: JobWorkflowStepResponse, type: 'expected' | 'maximum', e: React.MouseEvent) => void;
+  onCancelEditDuration: (e: React.MouseEvent) => void;
+  onSaveDuration: (step: JobWorkflowStepResponse, type: 'expected' | 'maximum', e: React.MouseEvent | React.KeyboardEvent) => void;
+  onStepUpdate?: () => void;
+  setStepNameValue: (val: string) => void;
+  setEditingNotes: (val: string) => void;
+  setEditDays: (val: number | string) => void;
+  setEditHours: (val: number | string) => void;
+}
+
+// ─── Sortable Step Component ──────────────────────────────────────────────────
+
+const SortableStepRow: React.FC<SortableStepRowProps> = ({
+  step,
+  index,
+  isLast,
+  isExpanded,
+  isReordering,
+  editingStepNameId,
+  stepNameValue,
+  updatingStep,
+  editingNotes,
+  editingStepId,
+  savingNotes,
+  editingDurationStepId,
+  editingDurationType,
+  editDays,
+  editHours,
+  workers,
+  allWorkers,
+  onToggleStep,
+  onStartEditStepName,
+  onCancelEditStepName,
+  onSaveStepName,
+  onDeleteStep,
+  onStatusChange,
+  onAssignedChange,
+  onEditNotes,
+  onCancelEditNotes,
+  onSaveNotes,
+  onEditDuration,
+  onCancelEditDuration,
+  onSaveDuration,
+  onStepUpdate,
+  setStepNameValue,
+  setEditingNotes,
+  setEditDays,
+  setEditHours,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `step-${step.id}`,
+    disabled: !isReordering,
+  });
+
+  const dndStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const statusInfo = getStatusInfo(step.status);
+  const assignedWorkerIdsList = Array.from(step.assignedWorkerIds || []);
+  const assignedWorker = assignedWorkerIdsList.length > 0 ? workers.get(assignedWorkerIdsList[0]) ?? null : null;
+  const selectedWorkers = assignedWorkerIdsList
+    .map((id) => allWorkers.find((w) => w.id === id) ?? workers.get(id))
+    .filter((w): w is WorkerResponse => !!w);
+
+  return (
+    <>
+      {/* ── Re-Order mode: compact draggable title row only ── */}
+      {isReordering ? (
+        <S.ReorderDragRow ref={setNodeRef} style={dndStyle} {...attributes} {...listeners}>
+          <S.DragIcon />
+          <S.ReorderDragIndex>{index + 1}</S.ReorderDragIndex>
+          <S.ReorderDragTitle>{step.name || `Step ${index + 1}`}</S.ReorderDragTitle>
+        </S.ReorderDragRow>
+      ) : (
+        /* ── Normal mode: full step row ── */
+        <S.StepRowContainer ref={setNodeRef} style={dndStyle}>
+          {/* Connector line */}
+          {!isLast && (
+            statusInfo.isCompleted ? <S.TimelineLineCompleted /> : <S.TimelineLinePending />
+          )}
+
+          {/* Node */}
+          <S.TimelineNode
+            statusVariant={statusInfo.variant}
+            onClick={() => step.id && onToggleStep(step.id)}
+          >
+            {statusInfo.isCompleted ? (
+              <S.NodeIconCheck />
+            ) : statusInfo.isInProgress ? (
+              <S.NodeIconPlay />
+            ) : statusInfo.isDelayed ? (
+              <S.NodeIconClose />
+            ) : (
+              index + 1
+            )}
+          </S.TimelineNode>
+
+          {/* Step Content */}
+          <S.StepContentBox>
+            {/* Step Title Header */}
+            <S.StepTitleHeaderRow>
+              {editingStepNameId === step.id ? (
+                <S.StepTitleEditWrapper>
+                  <S.StepTitleIndexSpan>{index + 1}.</S.StepTitleIndexSpan>
+                  <S.StepTitleTextField
+                    size="small"
+                    value={stepNameValue}
+                    onChange={(e) => setStepNameValue(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    autoFocus
+                  />
+                  <S.ActionIconButton size="small" onClick={onCancelEditStepName} aria-label="Cancel step name edit">
+                    <S.SmallIconClose />
+                  </S.ActionIconButton>
+                  <S.ActionIconButton
+                    size="small"
+                    onClick={(e) => onSaveStepName(step, e)}
+                    disabled={updatingStep === step.id}
+                    aria-label="Save step name"
+                  >
+                    <S.SmallIconSave />
+                  </S.ActionIconButton>
+                </S.StepTitleEditWrapper>
+              ) : (
+                <>
+                  <SPage.StepTitleText onClick={() => step.id && onToggleStep(step.id)}>
+                    {index + 1}. {step.name || `Step ${index + 1}`}
+                  </SPage.StepTitleText>
+
+                  {/* Action Buttons */}
+                  <S.StepActionButtonsBox>
+                    <S.ActionIconButton
+                      size="small"
+                      onClick={(e) => onStartEditStepName(step, e)}
+                      aria-label="Edit step title"
+                      title="Edit Step Title"
+                    >
+                      <S.SmallIconEdit />
+                    </S.ActionIconButton>
+                    <S.DeleteActionButton
+                      size="small"
+                      onClick={(e) => onDeleteStep(step, e)}
+                      disabled={updatingStep === step.id}
+                      aria-label="Delete step"
+                      title="Delete Step"
+                    >
+                      <S.SmallIconDelete />
+                    </S.DeleteActionButton>
+                  </S.StepActionButtonsBox>
+                </>
+              )}
+            </S.StepTitleHeaderRow>
+
+            {/* Step description */}
+            <S.StepDescriptionText>
+              {step.description || 'No description'}
+            </S.StepDescriptionText>
+
+            {/* Chips row */}
+            <S.ChipsRowBox onClick={() => step.id && onToggleStep(step.id)}>
+              <S.StyledStatusChip
+                label={statusInfo.label}
+                size="small"
+                chipbg={statusInfo.chipBg}
+                chipcolor={statusInfo.chipColor}
+              />
+              {assignedWorker && (
+                <S.AssignedYouChip label="YOU" size="small" />
+              )}
+              <SlaTimer step={step} />
+            </S.ChipsRowBox>
+
+            {/* Expanded details */}
+            <Collapse in={isExpanded}>
+              <S.ExpandedPanelBox>
+                {/* Expected duration */}
+                {step.expectedDurationMinutes != null && (
+                  <SPage.StepDetailRow>
+                    <span className="label">Expected Duration Time</span>
+                    {editingDurationStepId === step.id && editingDurationType === 'expected' ? (
+                      <S.DurationEditRowBox onClick={(e) => e.stopPropagation()}>
+                        <S.DurationNumberInput
+                          type="number" size="small" value={editDays}
+                          onChange={(e) => setEditDays(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') onSaveDuration(step, 'expected', e); }}
+                        />
+                        <S.DurationUnitText>day</S.DurationUnitText>
+                        <S.DurationNumberInput
+                          type="number" size="small" value={editHours}
+                          onChange={(e) => setEditHours(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') onSaveDuration(step, 'expected', e); }}
+                        />
+                        <S.DurationUnitText>hours</S.DurationUnitText>
+                        <S.ActionIconButton size="small" onClick={onCancelEditDuration}>
+                          <S.SmallIconClose />
+                        </S.ActionIconButton>
+                        <S.ActionIconButton size="small" onClick={(e) => onSaveDuration(step, 'expected', e)} disabled={updatingStep === step.id}>
+                          <S.SmallIconSave />
+                        </S.ActionIconButton>
+                      </S.DurationEditRowBox>
+                    ) : (
+                      <S.DurationValueBox>
+                        <S.DurationValueText>{formatDuration(step.expectedDurationMinutes)}</S.DurationValueText>
+                        <S.ActionIconButton size="small" onClick={(e) => onEditDuration(step, 'expected', e)}>
+                          <S.SmallIconEdit />
+                        </S.ActionIconButton>
+                      </S.DurationValueBox>
+                    )}
+                  </SPage.StepDetailRow>
+                )}
+
+                {/* Maximum duration */}
+                {step.maximumDurationMinutes != null && (
+                  <SPage.StepDetailRow>
+                    <span className="label">Maximum Duration Time</span>
+                    {editingDurationStepId === step.id && editingDurationType === 'maximum' ? (
+                      <S.DurationEditRowBox onClick={(e) => e.stopPropagation()}>
+                        <S.DurationNumberInput
+                          type="number" size="small" value={editDays}
+                          onChange={(e) => setEditDays(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') onSaveDuration(step, 'maximum', e); }}
+                        />
+                        <S.DurationUnitText>day</S.DurationUnitText>
+                        <S.DurationNumberInput
+                          type="number" size="small" value={editHours}
+                          onChange={(e) => setEditHours(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') onSaveDuration(step, 'maximum', e); }}
+                        />
+                        <S.DurationUnitText>hours</S.DurationUnitText>
+                        <S.ActionIconButton size="small" onClick={onCancelEditDuration}>
+                          <S.SmallIconClose />
+                        </S.ActionIconButton>
+                        <S.ActionIconButton size="small" onClick={(e) => onSaveDuration(step, 'maximum', e)} disabled={updatingStep === step.id}>
+                          <S.SmallIconSave />
+                        </S.ActionIconButton>
+                      </S.DurationEditRowBox>
+                    ) : (
+                      <S.DurationValueBox>
+                        <S.DurationValueText>{formatDuration(step.maximumDurationMinutes)}</S.DurationValueText>
+                        <S.ActionIconButton size="small" onClick={(e) => onEditDuration(step, 'maximum', e)}>
+                          <S.SmallIconEdit />
+                        </S.ActionIconButton>
+                      </S.DurationValueBox>
+                    )}
+                  </SPage.StepDetailRow>
+                )}
+
+                {/* Status dropdown */}
+                <SPage.StepDetailRow>
+                  <span className="label">Status</span>
+                  <S.StatusSelectControl size="small">
+                    <S.StatusSelectComponent
+                      value={step.status || JobWorkflowStepResponseStatusEnum.NotStarted}
+                      onChange={(e: any) => onStatusChange(step, e.target.value as string)}
+                      disabled={updatingStep === step.id}
+                    >
+                      {Object.entries(JobWorkflowStepResponseStatusEnum).map(([key, value]) => {
+                        const info = getStatusInfo(value);
+                        return (
+                          <MenuItem key={key} value={value}>
+                            <S.StatusMenuItemChip
+                              label={info.label}
+                              size="small"
+                              chipbg={info.chipBg}
+                              chipcolor={info.chipColor}
+                            />
+                          </MenuItem>
+                        );
+                      })}
+                    </S.StatusSelectComponent>
+                  </S.StatusSelectControl>
+                </SPage.StepDetailRow>
+
+                {/* Dates */}
+                {step.startedAt && (
+                  <SPage.StepDetailRow>
+                    <span className="label">Started At</span>
+                    <S.DateValueText>{formatStepDate(step.startedAt)}</S.DateValueText>
+                  </SPage.StepDetailRow>
+                )}
+                {step.completedAt && (
+                  <SPage.StepDetailRow>
+                    <span className="label">Completed At</span>
+                    <S.DateValueText>{formatStepDate(step.completedAt)}</S.DateValueText>
+                  </SPage.StepDetailRow>
+                )}
+
+                {/* Assigned */}
+                <SPage.AssignedRow>
+                  <span className="label">Assigned</span>
+                  <SPage.AssignedAutocompleteWrapper>
+                    <Autocomplete
+                      multiple
+                      fullWidth
+                      options={allWorkers}
+                      value={selectedWorkers}
+                      getOptionLabel={(option) => option.name || ''}
+                      isOptionEqualToValue={(option, value) => option.id === value.id}
+                      onChange={(_, newValue) =>
+                        onAssignedChange(step, newValue.map((w) => w.id!))
+                      }
+                      disabled={updatingStep === step.id}
+                      disablePortal
+                      disableCloseOnSelect
+                      size="small"
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          placeholder={selectedWorkers.length === 0 ? 'Unassigned' : ''}
+                          size="small"
+                        />
+                      )}
+                      renderOption={(props, option, { selected }) => {
+                        const { key, ...rest } = props as React.HTMLAttributes<HTMLLIElement> & { key: React.Key };
+                        return (
+                          <SPage.WorkerMenuItem key={key} {...rest} selected={selected}>
+                            {option.name}
+                          </SPage.WorkerMenuItem>
+                        );
+                      }}
+                      renderTags={(value, getTagProps) =>
+                        value.map((option, tagIndex) => {
+                          const tagProps = getTagProps({ index: tagIndex });
+                          return (
+                            <SPage.AssignedWorkerChip
+                              {...tagProps}
+                              key={tagProps.key}
+                              label={option.name}
+                              size="small"
+                            />
+                          );
+                        })
+                      }
+                    />
+                  </SPage.AssignedAutocompleteWrapper>
+                </SPage.AssignedRow>
+
+                {/* Notes */}
+                <SPage.EventNoteBox>
+                  <SPage.EventNoteHeader>
+                    <SPage.EventNoteTitle>Notes</SPage.EventNoteTitle>
+                    {editingStepId === step.id ? (
+                      <S.NotesEditButtonsRow>
+                        <SPage.EventNoteEditButton onClick={() => onCancelEditNotes()}>
+                          Cancel
+                        </SPage.EventNoteEditButton>
+                        <SPage.EventNoteEditButton onClick={() => onSaveNotes(step)} disabled={savingNotes}>
+                          {savingNotes ? 'Saving...' : 'Save'}
+                        </SPage.EventNoteEditButton>
+                      </S.NotesEditButtonsRow>
+                    ) : (
+                      <SPage.EventNoteEditButton onClick={(e) => onEditNotes(step, e)}>Edit</SPage.EventNoteEditButton>
+                    )}
+                  </SPage.EventNoteHeader>
+                  {editingStepId === step.id ? (
+                    <S.NotesTextField
+                      multiline
+                      rows={3}
+                      fullWidth
+                      size="small"
+                      value={editingNotes}
+                      onChange={(e) => setEditingNotes(e.target.value)}
+                      placeholder="Enter notes..."
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ) : (
+                    <SPage.EventNoteContent>{step.description || 'No notes added yet.'}</SPage.EventNoteContent>
+                  )}
+                </SPage.EventNoteBox>
+
+                {/* Attachments */}
+                {step.id && <StepAttachmentsSection stepId={step.id} onUpdate={onStepUpdate} />}
+
+                {/* Comments */}
+                {step.id && <StepCommentsSection stepId={step.id} onUpdate={onStepUpdate} />}
+              </S.ExpandedPanelBox>
+            </Collapse>
+          </S.StepContentBox>
+        </S.StepRowContainer>
+      )}
+    </>
+  );
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
 
 export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onStepUpdate }) => {
   const { showSuccess, showError } = useSnackbar();
-  const [jobWorkflow, setJobWorkflow]               = useState<JobWorkflowResponse | null>(null);
-  const [workflow, setWorkflow]                     = useState<WorkflowResponse | null>(null);
-  const [loading, setLoading]                       = useState(true);
-  const [expandedStepId, setExpandedStepId]         = useState<number | null>(null);
-  const [workers, setWorkers]                       = useState<Map<number, WorkerResponse>>(new Map());
-  const [allWorkers, setAllWorkers]                 = useState<WorkerResponse[]>([]);
-  const [editingStepId, setEditingStepId]           = useState<number | null>(null);
-  const [editingNotes, setEditingNotes]             = useState<string>('');
-  const [savingNotes, setSavingNotes]               = useState(false);
-  const [updatingStep, setUpdatingStep]             = useState<number | null>(null);
+  const [jobWorkflow, setJobWorkflow] = useState<JobWorkflowResponse | null>(null);
+  const [workflow, setWorkflow] = useState<WorkflowResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedStepId, setExpandedStepId] = useState<number | null>(null);
+  const [workers, setWorkers] = useState<Map<number, WorkerResponse>>(new Map());
+  const [allWorkers, setAllWorkers] = useState<WorkerResponse[]>([]);
+
+  // Re-order mode & local steps state
+  const [isReordering, setIsReordering] = useState(false);
+  const [localSteps, setLocalSteps] = useState<JobWorkflowStepResponse[]>([]);
+  const [savingReorder, setSavingReorder] = useState(false);
+
+  // Add step modal state
+  const [addModalOpen, setAddModalOpen] = useState(false);
+
+  // Editing step & workflow states
+  const [editingStepId, setEditingStepId] = useState<number | null>(null);
+  const [editingNotes, setEditingNotes] = useState<string>('');
+  const [savingNotes, setSavingNotes] = useState(false);
+  const [updatingStep, setUpdatingStep] = useState<number | null>(null);
   const [editingWorkflowName, setEditingWorkflowName] = useState(false);
-  const [workflowNameValue, setWorkflowNameValue]   = useState('');
+  const [workflowNameValue, setWorkflowNameValue] = useState('');
   const [savingWorkflowName, setSavingWorkflowName] = useState(false);
-  const [editingStepNameId, setEditingStepNameId]   = useState<number | null>(null);
-  const [stepNameValue, setStepNameValue]           = useState('');
+  const [editingStepNameId, setEditingStepNameId] = useState<number | null>(null);
+  const [stepNameValue, setStepNameValue] = useState('');
   const [editingDurationStepId, setEditingDurationStepId] = useState<number | null>(null);
-  const [editingDurationType, setEditingDurationType]     = useState<'expected' | 'maximum' | null>(null);
-  const [editDays, setEditDays]   = useState<number | string>('');
+  const [editingDurationType, setEditingDurationType] = useState<'expected' | 'maximum' | null>(null);
+  const [editDays, setEditDays] = useState<number | string>('');
   const [editHours, setEditHours] = useState<number | string>('');
+
+  // Sensors for Drag and Drop
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
 
   // ─── Data fetching ──────────────────────────────────────────────────────────
 
@@ -204,15 +645,21 @@ export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onSte
       const allWorkersResponse = await workerService.getAllWorkers();
       setAllWorkers(allWorkersResponse.data || []);
 
-      const activeStep = response.data.steps?.find(
-        (step) =>
-          step.status !== JobWorkflowStepResponseStatusEnum.Completed &&
-          step.status !== JobWorkflowStepResponseStatusEnum.Skipped
+      const sorted = response.data.steps
+        ? [...response.data.steps]
+            .sort((a, b) => (a.orderIndex || 0) - (b.orderIndex || 0))
+            .filter((step) => step.status !== JobWorkflowStepResponseStatusEnum.Skipped)
+        : [];
+      setLocalSteps(sorted);
+
+      const activeStep = sorted.find(
+        (step) => step.status !== JobWorkflowStepResponseStatusEnum.Completed
       );
       if (activeStep?.id) setExpandedStepId(activeStep.id);
     } catch {
       console.log('No workflow found for job:', job.id);
       setJobWorkflow(null);
+      setLocalSteps([]);
     } finally {
       setLoading(false);
     }
@@ -230,7 +677,7 @@ export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onSte
     if (step.id) { setEditingStepId(step.id); setEditingNotes(step.description || ''); }
   };
 
-  const handleCancelEdit = () => { setEditingStepId(null); setEditingNotes(''); };
+  const handleCancelEditNotes = () => { setEditingStepId(null); setEditingNotes(''); };
 
   const handleSaveNotes = async (step: JobWorkflowStepResponse) => {
     if (!step.id || !jobWorkflow?.id) return;
@@ -270,7 +717,7 @@ export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onSte
     if (!step.id || !jobWorkflow?.id) return;
     try {
       setUpdatingStep(step.id);
-      await jobWorkflowService.updateStep(jobWorkflow.id, step.id, { assignedWorkerIds: workerIds });
+      await jobWorkflowService.updateStep(jobWorkflow.id, step.id, { assignedWorkerIds: workerIds as any });
       showSuccess('Assignment updated successfully');
       fetchJobWorkflow();
       onStepUpdate?.();
@@ -335,6 +782,38 @@ export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onSte
     }
   };
 
+  const handleDeleteStep = async (step: JobWorkflowStepResponse, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!step.id || !jobWorkflow?.id) return;
+    try {
+      setUpdatingStep(step.id);
+      await jobWorkflowService.updateStep(jobWorkflow.id, step.id, {
+        status: JobWorkflowStepResponseStatusEnum.Skipped as any,
+      });
+      showSuccess('Step deleted successfully');
+      fetchJobWorkflow();
+      onStepUpdate?.();
+    } catch (error) {
+      console.error('Error deleting step:', error);
+      showError('Failed to delete step');
+    } finally {
+      setUpdatingStep(null);
+    }
+  };
+
+  const handleAddStepSubmit = async (data: JobWorkflowStepCreateRequest) => {
+    if (!jobWorkflow?.id) return;
+    try {
+      await jobWorkflowService.addStep(jobWorkflow.id, data);
+      showSuccess('Step added successfully to this job');
+      fetchJobWorkflow();
+      onStepUpdate?.();
+    } catch (error) {
+      console.error('Error adding step:', error);
+      showError('Failed to add step to job');
+    }
+  };
+
   const handleEditDuration = (step: JobWorkflowStepResponse, type: 'expected' | 'maximum', e: React.MouseEvent) => {
     e.stopPropagation();
     if (step.id) {
@@ -380,418 +859,229 @@ export const JobWorkflowStages: React.FC<JobWorkflowStagesProps> = ({ job, onSte
     }
   };
 
-  // ─── Derived state ───────────────────────────────────────────────────────────
+  // ─── Drag & Drop Reorder Handlers (LOCAL state only during drag) ────────────
 
-  const sortedSteps = jobWorkflow?.steps
-    ? [...jobWorkflow.steps].sort((a, b) => (a.orderIndex || 0) - (b.orderIndex || 0))
-    : [];
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = localSteps.findIndex((s) => `step-${s.id}` === active.id);
+    const newIndex = localSteps.findIndex((s) => `step-${s.id}` === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    // Rearrange local state ONLY (no API call during drag)
+    const newStepList = arrayMove(localSteps, oldIndex, newIndex);
+    setLocalSteps(newStepList);
+  };
+
+  // Final batch API call when clicking "Done"
+  const handleDoneReordering = async () => {
+    if (!jobWorkflow?.id) {
+      setIsReordering(false);
+      return;
+    }
+
+    try {
+      setSavingReorder(true);
+      const updatePromises = localSteps.map((step, idx) => {
+        if (!step.id) return Promise.resolve();
+        return jobWorkflowService.updateStep(jobWorkflow.id!, step.id, { orderIndex: idx + 1 });
+      });
+      await Promise.all(updatePromises);
+      showSuccess('Final step re-ordering saved successfully');
+      setIsReordering(false);
+      fetchJobWorkflow();
+      onStepUpdate?.();
+    } catch (err) {
+      console.error('Error committing reordered steps:', err);
+      showError('Failed to save final step order');
+      fetchJobWorkflow();
+    } finally {
+      setSavingReorder(false);
+    }
+  };
 
   // ─── Loading state ───────────────────────────────────────────────────────────
 
   if (loading) {
     return (
-      <S.WorkflowSidebar>
-        <S.WorkflowSidebarHeader>
-          <S.WorkflowSidebarTitle>Workflow Name</S.WorkflowSidebarTitle>
-        </S.WorkflowSidebarHeader>
-        <Box sx={styles.loadingContainer}>
+      <SPage.WorkflowSidebar>
+        <SPage.WorkflowSidebarHeader>
+          <SPage.WorkflowSidebarTitle>Workflow Steps</SPage.WorkflowSidebarTitle>
+        </SPage.WorkflowSidebarHeader>
+        <S.LoadingContainer>
           <CircularProgress size={32} />
-        </Box>
-      </S.WorkflowSidebar>
+        </S.LoadingContainer>
+      </SPage.WorkflowSidebar>
     );
   }
 
   // ─── Empty state ─────────────────────────────────────────────────────────────
 
-  if (!jobWorkflow || sortedSteps.length === 0) {
+  if (!jobWorkflow || localSteps.length === 0) {
     return (
-      <S.WorkflowSidebar>
-        <S.WorkflowSidebarHeader>
-          <S.WorkflowSidebarTitle>Workflow Name</S.WorkflowSidebarTitle>
-          <IconButton size="small">
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </S.WorkflowSidebarHeader>
-        <Box px={2} py={3}>
-          <S.PlaceholderText>No workflow assigned to this job</S.PlaceholderText>
-        </Box>
-      </S.WorkflowSidebar>
+      <SPage.WorkflowSidebar>
+        <SPage.WorkflowSidebarHeader>
+          <SPage.WorkflowSidebarTitle>Workflow Steps</SPage.WorkflowSidebarTitle>
+        </SPage.WorkflowSidebarHeader>
+        <S.EmptyStateContainer>
+          <SPage.PlaceholderText>No workflow steps assigned to this job</SPage.PlaceholderText>
+          {jobWorkflow?.id && (
+            <S.AddStepCardButton onClick={() => setAddModalOpen(true)}>
+              <S.SmallIconAdd /> Add New Step
+            </S.AddStepCardButton>
+          )}
+        </S.EmptyStateContainer>
+
+        {jobWorkflow?.id && (
+          <AddStepModal
+            open={addModalOpen}
+            onClose={() => setAddModalOpen(false)}
+            onSubmit={handleAddStepSubmit}
+            allWorkers={allWorkers}
+            nextOrderIndex={1}
+          />
+        )}
+      </SPage.WorkflowSidebar>
     );
   }
 
-  // ─── Main render ─────────────────────────────────────────────────────────────
+  // ─── Main Render ─────────────────────────────────────────────────────────────
 
   return (
-    <S.WorkflowSidebar>
-      {/* ── Header ── */}
-      <S.WorkflowSidebarHeader>
-        <S.WorkflowSidebarTitle>
+    <SPage.WorkflowSidebar>
+      {/* Header */}
+      <SPage.WorkflowSidebarHeader>
+        <SPage.WorkflowSidebarTitle>
           {editingWorkflowName ? (
-            <TextField
+            <S.WorkflowNameInput
               size="small"
               value={workflowNameValue}
               onChange={(e) => setWorkflowNameValue(e.target.value)}
               autoFocus
-              sx={styles.workflowNameTextField}
             />
           ) : (
             <>
               {workflow?.name || 'Workflow Name'}
-              <Box component="span" sx={styles.workflowNameAvatarRow}>
+              <S.WorkerAvatarsRow>
                 {Array.from(workers.values())
                   .slice(0, 2)
                   .map((worker) => (
-                    <Box key={worker.id} sx={styles.workerAvatar}>
+                    <S.WorkerAvatarBox key={worker.id}>
                       {worker.initials || worker.name?.substring(0, 2).toUpperCase()}
-                    </Box>
+                    </S.WorkerAvatarBox>
                   ))}
-              </Box>
+              </S.WorkerAvatarsRow>
             </>
           )}
-        </S.WorkflowSidebarTitle>
+        </SPage.WorkflowSidebarTitle>
 
-        {editingWorkflowName ? (
-          <Box sx={styles.workflowNameEditButtons}>
-            <IconButton size="small" onClick={handleCancelWorkflowNameEdit} aria-label="Cancel workflow name edit">
-              <CloseIcon fontSize="small" />
-            </IconButton>
-            <IconButton size="small" onClick={handleSaveWorkflowName} disabled={savingWorkflowName} aria-label="Save workflow name">
-              <SaveIcon fontSize="small" />
-            </IconButton>
-          </Box>
-        ) : (
-          <IconButton size="small" onClick={handleEditWorkflowName} aria-label="Edit workflow name">
-            <EditIcon fontSize="small" />
-          </IconButton>
-        )}
-      </S.WorkflowSidebarHeader>
+        <S.HeaderActionsBox>
+          {editingWorkflowName ? (
+            <S.HeaderButtonsRow>
+              <IconButton size="small" onClick={handleCancelWorkflowNameEdit} aria-label="Cancel workflow name edit">
+                <CloseIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={handleSaveWorkflowName} disabled={savingWorkflowName} aria-label="Save workflow name">
+                <SaveIcon fontSize="small" />
+              </IconButton>
+            </S.HeaderButtonsRow>
+          ) : (
+            <>
+              <IconButton size="small" onClick={handleEditWorkflowName} aria-label="Edit workflow name">
+                <EditIcon fontSize="small" />
+              </IconButton>
 
-      {/* ── Timeline list ── */}
-      <Box sx={styles.timelineList}>
-        {sortedSteps.map((step, index) => {
-          const statusInfo = getStatusInfo(step.status);
-          const isLast     = index === sortedSteps.length - 1;
-          const isExpanded = step.id === expandedStepId;
+              {/* White background Re-Order / Done button */}
+              <S.ReOrderWhiteButton
+                variant="outlined"
+                size="small"
+                isreordering={isReordering ? 'true' : 'false'}
+                disabled={savingReorder}
+                onClick={() => {
+                  if (isReordering) {
+                    handleDoneReordering();
+                  } else {
+                    setIsReordering(true);
+                  }
+                }}
+              >
+                {savingReorder ? 'Saving...' : isReordering ? 'Done' : 'Re-Order'}
+              </S.ReOrderWhiteButton>
 
-          const assignedWorkerIdsList = Array.from(step.assignedWorkerIds || []);
-          const assignedWorker        = assignedWorkerIdsList.length > 0
-            ? workers.get(assignedWorkerIdsList[0]) ?? null
-            : null;
-          const selectedWorkers = assignedWorkerIdsList
-            .map((id) => allWorkers.find((w) => w.id === id) ?? workers.get(id))
-            .filter((w): w is WorkerResponse => !!w);
 
-          // Resolve which node style to use
-          const nodeStyle = statusInfo.isCompleted
-            ? styles.timelineNodeCompleted
-            : statusInfo.isInProgress
-              ? styles.timelineNodeInProgress
-              : statusInfo.isDelayed
-                ? styles.timelineNodeDelayed
-                : styles.timelineNodeDefault;
+            </>
+          )}
+        </S.HeaderActionsBox>
+      </SPage.WorkflowSidebarHeader>
 
-          return (
-            <Box key={step.id || index} sx={styles.stepRow}>
-              {/* Connector line */}
-              {!isLast && (
-                <Box sx={statusInfo.isCompleted ? styles.timelineLineCompleted : styles.timelineLinePending} />
-              )}
+      {/* Timeline list with DndContext */}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={localSteps.map((s) => `step-${s.id}`)} strategy={verticalListSortingStrategy}>
+          <S.TimelineListWrapper>
+            {localSteps.map((step, index) => {
+              const isLast = index === localSteps.length - 1;
+              const isExpanded = step.id === expandedStepId;
 
-              {/* Node */}
-              <Box onClick={() => step.id && toggleStep(step.id)} sx={nodeStyle}>
-                {statusInfo.isCompleted ? (
-                  <CheckIcon sx={{ fontSize: 16 }} />
-                ) : statusInfo.isInProgress ? (
-                  <PlayArrowIcon sx={{ fontSize: 16 }} />
-                ) : statusInfo.isDelayed ? (
-                  <CloseIcon sx={{ fontSize: 16 }} />
-                ) : (
-                  index + 1
-                )}
-              </Box>
+              return (
+                <SortableStepRow
+                  key={step.id || index}
+                  step={step}
+                  index={index}
+                  isLast={isLast}
+                  isExpanded={isExpanded}
+                  isReordering={isReordering}
+                  editingStepNameId={editingStepNameId}
+                  stepNameValue={stepNameValue}
+                  updatingStep={updatingStep}
+                  editingNotes={editingNotes}
+                  editingStepId={editingStepId}
+                  savingNotes={savingNotes}
+                  editingDurationStepId={editingDurationStepId}
+                  editingDurationType={editingDurationType}
+                  editDays={editDays}
+                  editHours={editHours}
+                  workers={workers}
+                  allWorkers={allWorkers}
+                  onToggleStep={toggleStep}
+                  onStartEditStepName={handleEditStepName}
+                  onCancelEditStepName={handleCancelStepNameEdit}
+                  onSaveStepName={handleSaveStepName}
+                  onDeleteStep={handleDeleteStep}
+                  onStatusChange={handleStatusChange}
+                  onAssignedChange={handleAssignedChange}
+                  onEditNotes={handleEditNotes}
+                  onCancelEditNotes={handleCancelEditNotes}
+                  onSaveNotes={handleSaveNotes}
+                  onEditDuration={handleEditDuration}
+                  onCancelEditDuration={handleCancelEditDuration}
+                  onSaveDuration={handleSaveDuration}
+                  onStepUpdate={onStepUpdate}
+                  setStepNameValue={setStepNameValue}
+                  setEditingNotes={setEditingNotes}
+                  setEditDays={setEditDays}
+                  setEditHours={setEditHours}
+                />
+              );
+            })}
 
-              {/* Step content */}
-              <Box sx={styles.stepContent}>
+            {/* Always available Add Step Card Button at bottom */}
+            <S.AddStepCardButton onClick={() => setAddModalOpen(true)}>
+              <S.SmallIconAdd /> Add New Step
+            </S.AddStepCardButton>
+          </S.TimelineListWrapper>
+        </SortableContext>
+      </DndContext>
 
-                {/* Step title */}
-                <S.StepTitleContainer>
-                  {editingStepNameId === step.id ? (
-                    <S.StepTitleEditContainer>
-                      <S.StepTitleIndex>{index + 1}.</S.StepTitleIndex>
-                      <TextField
-                        size="small"
-                        value={stepNameValue}
-                        onChange={(e) => setStepNameValue(e.target.value)}
-                        onClick={(e) => e.stopPropagation()}
-                        autoFocus
-                        sx={styles.stepNameTextField}
-                      />
-                      <IconButton size="small" onClick={handleCancelStepNameEdit} aria-label="Cancel step name edit">
-                        <CloseIcon sx={{ fontSize: 14 }} />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleSaveStepName(step, e)}
-                        disabled={updatingStep === step.id}
-                        aria-label="Save step name"
-                      >
-                        <SaveIcon sx={{ fontSize: 14 }} />
-                      </IconButton>
-                    </S.StepTitleEditContainer>
-                  ) : (
-                    <>
-                      <S.StepTitleText onClick={(e) => handleEditStepName(step, e)}>
-                        {index + 1}. {step.name || `Step ${index + 1}`}
-                      </S.StepTitleText>
-                      <S.StepTitleEditButton onClick={(e) => handleEditStepName(step, e)}>
-                        <EditIcon sx={{ fontSize: 14 }} />
-                      </S.StepTitleEditButton>
-                    </>
-                  )}
-                </S.StepTitleContainer>
-
-                {/* Step description */}
-                <Box sx={styles.stepDescription}>
-                  {step.description || 'No description'}
-                </Box>
-
-                {/* Chips row */}
-                <Box onClick={() => step.id && toggleStep(step.id)} sx={styles.chipsRow}>
-                  <Chip
-                    label={statusInfo.label}
-                    size="small"
-                    sx={{
-                      ...styles.statusChip,
-                      backgroundColor: statusInfo.chipBg,
-                      color: statusInfo.chipColor,
-                    }}
-                  />
-                  {assignedWorker && (
-                    <Chip label="YOU" size="small" sx={styles.assignedChip} />
-                  )}
-                  <SlaTimer step={step} />
-                </Box>
-
-                {/* Expanded details */}
-                <Collapse in={isExpanded}>
-                  <Box sx={styles.expandedPanel}>
-
-                    {/* Expected duration */}
-                    {step.expectedDurationMinutes != null && (
-                      <S.StepDetailRow>
-                        <span className="label">Expected Duration Time</span>
-                        {editingDurationStepId === step.id && editingDurationType === 'expected' ? (
-                          <Box sx={styles.durationEditRow} onClick={(e) => e.stopPropagation()}>
-                            <TextField
-                              type="number" size="small" value={editDays}
-                              onChange={(e) => setEditDays(e.target.value)}
-                              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveDuration(step, 'expected', e); }}
-                              sx={styles.durationTextField}
-                            />
-                            <span style={styles.durationLabel}>day</span>
-                            <TextField
-                              type="number" size="small" value={editHours}
-                              onChange={(e) => setEditHours(e.target.value)}
-                              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveDuration(step, 'expected', e); }}
-                              sx={styles.durationTextField}
-                            />
-                            <span style={styles.durationLabel}>hours</span>
-                            <IconButton size="small" onClick={handleCancelEditDuration}>
-                              <CloseIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                            <IconButton size="small" onClick={(e) => handleSaveDuration(step, 'expected', e)} disabled={updatingStep === step.id}>
-                              <SaveIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                          </Box>
-                        ) : (
-                          <Box sx={styles.durationValueBox}>
-                            <span style={styles.durationValueText}>{formatDuration(step.expectedDurationMinutes)}</span>
-                            <IconButton size="small" onClick={(e) => handleEditDuration(step, 'expected', e)} sx={styles.durationEditIconButton}>
-                              <EditIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                          </Box>
-                        )}
-                      </S.StepDetailRow>
-                    )}
-
-                    {/* Maximum duration */}
-                    {step.maximumDurationMinutes != null && (
-                      <S.StepDetailRow>
-                        <span className="label">Maximum Duration Time</span>
-                        {editingDurationStepId === step.id && editingDurationType === 'maximum' ? (
-                          <Box sx={styles.durationEditRow} onClick={(e) => e.stopPropagation()}>
-                            <TextField
-                              type="number" size="small" value={editDays}
-                              onChange={(e) => setEditDays(e.target.value)}
-                              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveDuration(step, 'maximum', e); }}
-                              sx={styles.durationTextField}
-                            />
-                            <span style={styles.durationLabel}>day</span>
-                            <TextField
-                              type="number" size="small" value={editHours}
-                              onChange={(e) => setEditHours(e.target.value)}
-                              onKeyDown={(e) => { if (e.key === 'Enter') handleSaveDuration(step, 'maximum', e); }}
-                              sx={styles.durationTextField}
-                            />
-                            <span style={styles.durationLabel}>hours</span>
-                            <IconButton size="small" onClick={handleCancelEditDuration}>
-                              <CloseIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                            <IconButton size="small" onClick={(e) => handleSaveDuration(step, 'maximum', e)} disabled={updatingStep === step.id}>
-                              <SaveIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                          </Box>
-                        ) : (
-                          <Box sx={styles.durationValueBox}>
-                            <span style={styles.durationValueText}>{formatDuration(step.maximumDurationMinutes)}</span>
-                            <IconButton size="small" onClick={(e) => handleEditDuration(step, 'maximum', e)} sx={styles.durationEditIconButton}>
-                              <EditIcon sx={{ fontSize: 14 }} />
-                            </IconButton>
-                          </Box>
-                        )}
-                      </S.StepDetailRow>
-                    )}
-
-                    {/* Status dropdown */}
-                    <S.StepDetailRow>
-                      <span className="label">Status</span>
-                      <FormControl size="small" sx={styles.statusSelect}>
-                        <Select
-                          value={step.status || JobWorkflowStepResponseStatusEnum.NotStarted}
-                          onChange={(e: SelectChangeEvent) => handleStatusChange(step, e.target.value)}
-                          disabled={updatingStep === step.id}
-                          sx={styles.statusSelectInput}
-                        >
-                          {Object.entries(JobWorkflowStepResponseStatusEnum).map(([key, value]) => {
-                            const info = getStatusInfo(value);
-                            return (
-                              <MenuItem key={key} value={value} sx={{ fontSize: 12 }}>
-                                <Chip
-                                  label={info.label}
-                                  size="small"
-                                  sx={{
-                                    ...styles.statusMenuItemChip,
-                                    backgroundColor: info.chipBg,
-                                    color: info.chipColor,
-                                  }}
-                                />
-                              </MenuItem>
-                            );
-                          })}
-                        </Select>
-                      </FormControl>
-                    </S.StepDetailRow>
-
-                    {/* Dates */}
-                    {step.startedAt && (
-                      <S.StepDetailRow>
-                        <span className="label">Started At</span>
-                        <span style={styles.dateValueText}>{formatStepDate(step.startedAt)}</span>
-                      </S.StepDetailRow>
-                    )}
-                    {step.completedAt && (
-                      <S.StepDetailRow>
-                        <span className="label">Completed At</span>
-                        <span style={styles.dateValueText}>{formatStepDate(step.completedAt)}</span>
-                      </S.StepDetailRow>
-                    )}
-
-                    {/* Assigned */}
-                    <S.AssignedRow>
-                      <span className="label">Assigned</span>
-                      <S.AssignedAutocompleteWrapper>
-                        <Autocomplete
-                          multiple
-                          fullWidth
-                          options={allWorkers}
-                          value={selectedWorkers}
-                          getOptionLabel={(option) => option.name || ''}
-                          isOptionEqualToValue={(option, value) => option.id === value.id}
-                          onChange={(_, newValue) =>
-                            handleAssignedChange(step, newValue.map((w) => w.id!))
-                          }
-                          disabled={updatingStep === step.id}
-                          disablePortal
-                          disableCloseOnSelect
-                          size="small"
-                          renderInput={(params) => (
-                            <TextField
-                              {...params}
-                              placeholder={selectedWorkers.length === 0 ? 'Unassigned' : ''}
-                              size="small"
-                            />
-                          )}
-                          renderOption={(props, option, { selected }) => {
-                            const { key, ...rest } = props as React.HTMLAttributes<HTMLLIElement> & { key: React.Key };
-                            return (
-                              <S.WorkerMenuItem key={key} {...rest} selected={selected}>
-                                {option.name}
-                              </S.WorkerMenuItem>
-                            );
-                          }}
-                          renderTags={(value, getTagProps) =>
-                            value.map((option, index) => {
-                              const tagProps = getTagProps({ index });
-                              return (
-                                <S.AssignedWorkerChip
-                                  {...tagProps}
-                                  key={tagProps.key}
-                                  label={option.name}
-                                  size="small"
-                                />
-                              );
-                            })
-                          }
-                        />
-                      </S.AssignedAutocompleteWrapper>
-                    </S.AssignedRow>
-
-                    {/* Notes */}
-                    <S.EventNoteBox>
-                      <S.EventNoteHeader>
-                        <S.EventNoteTitle>Notes</S.EventNoteTitle>
-                        {editingStepId === step.id ? (
-                          <Box sx={styles.notesEditButtonRow}>
-                            <S.EventNoteEditButton onClick={() => handleCancelEdit()} style={{ color: '#666' }}>
-                              Cancel
-                            </S.EventNoteEditButton>
-                            <S.EventNoteEditButton onClick={() => handleSaveNotes(step)} disabled={savingNotes}>
-                              {savingNotes ? 'Saving...' : 'Save'}
-                            </S.EventNoteEditButton>
-                          </Box>
-                        ) : (
-                          <S.EventNoteEditButton onClick={(e) => handleEditNotes(step, e)}>Edit</S.EventNoteEditButton>
-                        )}
-                      </S.EventNoteHeader>
-                      {editingStepId === step.id ? (
-                        <TextField
-                          multiline
-                          rows={3}
-                          fullWidth
-                          size="small"
-                          value={editingNotes}
-                          onChange={(e) => setEditingNotes(e.target.value)}
-                          placeholder="Enter notes..."
-                          onClick={(e) => e.stopPropagation()}
-                          sx={styles.notesTextField}
-                        />
-                      ) : (
-                        <S.EventNoteContent>{step.description || 'No notes added yet.'}</S.EventNoteContent>
-                      )}
-                    </S.EventNoteBox>
-
-                    {/* Attachments */}
-                    {step.id && <StepAttachmentsSection stepId={step.id} onUpdate={onStepUpdate} />}
-
-                    {/* Comments */}
-                    {step.id && <StepCommentsSection stepId={step.id} onUpdate={onStepUpdate} />}
-                  </Box>
-                </Collapse>
-              </Box>
-            </Box>
-          );
-        })}
-      </Box>
-    </S.WorkflowSidebar>
+      {/* Add step modal */}
+      <AddStepModal
+        open={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        onSubmit={handleAddStepSubmit}
+        allWorkers={allWorkers}
+        nextOrderIndex={localSteps.length + 1}
+      />
+    </SPage.WorkflowSidebar>
   );
 };

--- a/src/pages/jobs/components/JobWorkflowStages/StepAttachmentsSection.tsx
+++ b/src/pages/jobs/components/JobWorkflowStages/StepAttachmentsSection.tsx
@@ -1,18 +1,14 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { Tooltip } from '@mui/material';
-import AttachFileIcon from '@mui/icons-material/AttachFile';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
-import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
-import ImageIcon from '@mui/icons-material/Image';
-import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
-import DescriptionIcon from '@mui/icons-material/Description';
 import { stepActivityService } from '../../../../services/api';
 import type { StepAttachmentResponse } from '../../../../services/api';
 import { useSnackbar } from '../../../../contexts/SnackbarContext';
 import { Loader } from '../../../../components/UI/Loader/Loader';
 import { IconButton } from '../../../../components/UI/Button/IconButton';
-import * as S from '../../JobDetailsPage.styles';
+import * as SPage from '../../JobDetailsPage.styles';
+import * as S from './JobWorkflowStages.styles';
 
 interface StepAttachmentsSectionProps {
   stepId: number;
@@ -20,18 +16,18 @@ interface StepAttachmentsSectionProps {
 }
 
 const getFileIcon = (fileType?: string) => {
-  if (!fileType) return <InsertDriveFileIcon fontSize="small" />;
+  if (!fileType) return <S.StyledGenericFileIcon />;
 
   if (fileType.startsWith('image/')) {
-    return <ImageIcon fontSize="small" sx={{ color: 'success.main' }} />;
+    return <S.StyledImageIcon />;
   }
   if (fileType === 'application/pdf') {
-    return <PictureAsPdfIcon fontSize="small" sx={{ color: 'error.main' }} />;
+    return <S.StyledPdfIcon />;
   }
   if (fileType.includes('word') || fileType.includes('document')) {
-    return <DescriptionIcon fontSize="small" sx={{ color: 'info.main' }} />;
+    return <S.StyledDocIcon />;
   }
-  return <InsertDriveFileIcon fontSize="small" sx={{ color: 'text.secondary' }} />;
+  return <S.StyledGenericFileIcon />;
 };
 
 export const StepAttachmentsSection: React.FC<StepAttachmentsSectionProps> = ({ stepId, onUpdate }) => {
@@ -106,51 +102,50 @@ export const StepAttachmentsSection: React.FC<StepAttachmentsSectionProps> = ({ 
 
   if (loading) {
     return (
-      <S.EventNoteBox>
-        <S.EventNoteHeader>
-          <S.EventNoteTitle>Attachments</S.EventNoteTitle>
-        </S.EventNoteHeader>
+      <SPage.EventNoteBox>
+        <SPage.EventNoteHeader>
+          <SPage.EventNoteTitle>Attachments</SPage.EventNoteTitle>
+        </SPage.EventNoteHeader>
         <Loader size={20} centered minHeight="60px" />
-      </S.EventNoteBox>
+      </SPage.EventNoteBox>
     );
   }
 
   return (
-    <S.EventNoteBox>
-      <S.EventNoteHeader>
-        <S.EventNoteTitle>Attachments</S.EventNoteTitle>
-        <S.EventNoteEditButton onClick={handleUploadClick} disabled={uploading}>
+    <SPage.EventNoteBox>
+      <SPage.EventNoteHeader>
+        <SPage.EventNoteTitle>Attachments</SPage.EventNoteTitle>
+        <SPage.EventNoteEditButton onClick={handleUploadClick} disabled={uploading}>
           {uploading ? 'Uploading...' : 'Add'}
-        </S.EventNoteEditButton>
-      </S.EventNoteHeader>
+        </SPage.EventNoteEditButton>
+      </SPage.EventNoteHeader>
 
-      <input
+      <S.HiddenFileInput
         type="file"
         ref={fileInputRef}
         onChange={handleFileChange}
-        style={{ display: 'none' }}
         onClick={(e) => e.stopPropagation()}
       />
 
       {attachments.length === 0 ? (
-        <S.UploadDropzone onClick={handleUploadClick}>
-          <AttachFileIcon sx={{ fontSize: 24, color: 'text.secondary', mb: 0.5 }} />
-          <S.EventNoteContent>Click to upload attachments</S.EventNoteContent>
-        </S.UploadDropzone>
+        <SPage.UploadDropzone onClick={handleUploadClick}>
+          <S.StyledAttachFileIcon />
+          <SPage.EventNoteContent>Click to upload attachments</SPage.EventNoteContent>
+        </SPage.UploadDropzone>
       ) : (
-        <S.AttachmentList>
+        <SPage.AttachmentList>
           {attachments.map((attachment) => (
-            <S.AttachmentItem key={attachment.id}>
+            <SPage.AttachmentItem key={attachment.id}>
               {getFileIcon(attachment.fileType)}
-              <S.AttachmentFileName>
+              <SPage.AttachmentFileName>
                 <div className="name">{attachment.fileName || 'Unnamed file'}</div>
                 {attachment.createdAt && (
                   <div className="date">
                     {new Date(attachment.createdAt).toLocaleDateString()}
                   </div>
                 )}
-              </S.AttachmentFileName>
-              <S.AttachmentActions>
+              </SPage.AttachmentFileName>
+              <SPage.AttachmentActions>
                 <Tooltip title="Download">
                   <IconButton
                     size="small"
@@ -166,23 +161,24 @@ export const StepAttachmentsSection: React.FC<StepAttachmentsSectionProps> = ({ 
                   <IconButton
                     size="small"
                     variant="text"
-                    color="danger"
+                    color="error"
                     onClick={(e) => attachment.id && handleDeleteAttachment(attachment.id, e)}
                     aria-label="Delete attachment"
                   >
                     <DeleteIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
-              </S.AttachmentActions>
-            </S.AttachmentItem>
+              </SPage.AttachmentActions>
+            </SPage.AttachmentItem>
           ))}
 
-          <S.AddMoreButton onClick={handleUploadClick}>
-            <AttachFileIcon sx={{ fontSize: 14 }} />
+          <SPage.AddMoreButton onClick={handleUploadClick}>
+            <S.StyledAttachFileSmallIcon />
             Add more
-          </S.AddMoreButton>
-        </S.AttachmentList>
+          </SPage.AddMoreButton>
+        </SPage.AttachmentList>
       )}
-    </S.EventNoteBox>
+    </SPage.EventNoteBox>
   );
 };
+

--- a/src/services/api/jobWorkflow.ts
+++ b/src/services/api/jobWorkflow.ts
@@ -4,6 +4,7 @@ import type {
   JobWorkflowUpdateRequest,
   JobWorkflowStepResponse,
   JobWorkflowStepUpdateRequest,
+  JobWorkflowStepCreateRequest,
 } from '../../../workflow-api';
 import { env } from '../../config/env';
 import { axiosInstance } from './axiosConfig';
@@ -13,6 +14,7 @@ export type {
   JobWorkflowUpdateRequest,
   JobWorkflowStepResponse,
   JobWorkflowStepUpdateRequest,
+  JobWorkflowStepCreateRequest,
 };
 
 function getJobWorkflowApi(): JobWorkflowsApi {
@@ -41,6 +43,10 @@ export const jobWorkflowService = {
     return await getJobWorkflowApi().jobWorkflowUpdateJobWorkflow(jobWorkflowId, data);
   },
 
+  async addStep(jobWorkflowId: number, data: JobWorkflowStepCreateRequest) {
+    return await getJobWorkflowApi().jobWorkflowAddStep(jobWorkflowId, data);
+  },
+
   async updateStep(jobWorkflowId: number, stepId: number, data: JobWorkflowStepUpdateRequest) {
     return await getJobWorkflowApi().jobWorkflowUpdateStep(jobWorkflowId, stepId, data);
   },
@@ -55,3 +61,4 @@ export const jobWorkflowService = {
 };
 
 export default jobWorkflowService;
+


### PR DESCRIPTION
…ity tab

- Workflow steps: when reorder mode is enabled, show only step title and make the entire row draggable (DnD via dnd-kit)

- Step Activity tab: add inline edit & delete for step comments
  - Hover any message to reveal a pen (edit) and red trash (delete) button
  - Edit opens an inline text field; Enter saves, Esc cancels
  - Calls updateComment / deleteComment APIs and refreshes the feed
  - Only shown on COMMENT items, not attachments

- All new styles extracted to .styles.ts files — no inline sx in TSX

- Fixed blank/white page regressions caused by brace-mismatch in JobWorkflowStages.tsx during the refactor; cleaned up stale duplicate code blocks