### PR TITLE
fix(ui): center worklog details popup and preserve message newlines

### DIFF
--- a/src/pages/jobs/JobDetailsPage.styles.ts
+++ b/src/pages/jobs/JobDetailsPage.styles.ts
@@ -750,6 +750,7 @@ export const EventNoteContent = styled('p')(({ theme }) => ({
   color: theme.palette.text.secondary,
   margin: 0,
   lineHeight: 1.5,
+  whiteSpace: 'pre-wrap',
 }));
 
 // Main Content Panel
@@ -2713,9 +2714,11 @@ export const ActivityBubble = styled(Box)(({ theme }) => ({
   color: theme.palette.text.primary,
   lineHeight: 1.6,
   wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap',
 }));
 
 export const ActivityBubbleHtml = styled(Box)(() => ({
+  whiteSpace: 'pre-wrap',
   '& p': { margin: 0 },
   '& ul, & ol': { margin: `${rem(4)} 0`, paddingLeft: rem(20) },
   '& strong': { fontWeight: Bold._700 },

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.styles.ts
@@ -1,8 +1,44 @@
-import { Box, Typography, styled } from '@mui/material';
+import { Box, Typography, styled, IconButton } from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import SearchIcon from '@mui/icons-material/Search';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { rem, Bold } from '../../../../../components/UI/Typography/utility';
 import { floowColors } from '../../../../../theme/colors';
+import { EmptyFeedBox } from './StepActivityTab.styles';
 
-export { EmptyFeedBox } from './StepActivityTab.styles';
+export const WorkLogsEmptyFeedBox = styled(EmptyFeedBox)(() => ({
+  minHeight: rem(300),
+}));
+
+export const EmptyFeedIcon = styled(AccessTimeIcon)(({ theme }) => ({
+  fontSize: rem(48),
+  color: theme.palette.colors.grey_200,
+}));
+
+export const JumpToStepButton = styled(IconButton)(() => ({
+  width: rem(32),
+  height: rem(32),
+  padding: 0,
+}));
+
+export const SearchStepIcon = styled(SearchIcon)(() => ({
+  fontSize: rem(20),
+}));
+
+export const TimerIcon = styled(AccessTimeIcon)(() => ({
+  fontSize: rem(32),
+  color: 'white',
+}));
+
+export const ActionEditIcon = styled(EditIcon)(() => ({
+  fontSize: rem(16),
+}));
+
+export const ActionDeleteIcon = styled(DeleteIcon)(() => ({
+  fontSize: rem(16),
+}));
+
 
 // ─── Outer Layout (Rail + Right Content) ──────────────────────────────────────
 
@@ -322,7 +358,7 @@ export const Tr = styled('tr')(() => ({
 }));
 
 // Data rows — 3.5rem height, clickable
-export const DataTr = styled('tr')(({ theme }) => ({
+export const DataTr = styled('tr')(() => ({
   height: rem(56),
   maxHeight: rem(56),
   cursor: 'pointer',
@@ -359,7 +395,7 @@ export const NotesTd = styled('td')(({ theme }) => ({
   textOverflow: 'ellipsis',
 }));
 
-export const UserBadge = styled(Box)(({ theme }) => ({
+export const UserBadge = styled(Box)(() => ({
   display: 'flex',
   alignItems: 'center',
   gap: rem(6),
@@ -412,16 +448,11 @@ export const NotePopupBackdrop = styled(Box)(() => ({
   backgroundColor: 'rgba(0, 0, 0, 0.22)',
 }));
 
-// Card is fixed-positioned and centred on the clicked row.
-// `yOffset` (px from top of viewport) is the row's vertical mid-point.
-export const NotePopupCard = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'yOffset',
-})<{ yOffset?: number }>(({ theme, yOffset }) => ({
+// Card is fixed-positioned and centered in the viewport.
+export const NotePopupCard = styled(Box)(({ theme }) => ({
   position: 'fixed',
-  // Horizontally centred in the viewport
   left: '50%',
-  // Vertically centred on the clicked row; fall back to viewport centre
-  top: yOffset !== undefined ? `${yOffset}px` : '50vh',
+  top: '50%',
   transform: 'translate(-50%, -50%)',
   zIndex: 1301,
   backgroundColor: theme.palette.colors.white,
@@ -429,15 +460,17 @@ export const NotePopupCard = styled(Box, {
   boxShadow: `0 ${rem(8)} ${rem(32)} rgba(0,0,0,0.16)`,
   padding: `${rem(14)} ${rem(18)}`,
   minWidth: rem(180),
-  maxWidth: rem(440),
+  maxWidth: '80vw',
+  maxHeight: '80vh',
   width: 'fit-content',
+  height: 'fit-content',
   display: 'flex',
   flexDirection: 'column',
   gap: rem(6),
   border: `${rem(1)} solid ${theme.palette.colors.grey_200}`,
   [theme.breakpoints.down('sm')]: {
-    maxWidth: `calc(100vw - ${rem(32)})`,
-    width: `calc(100vw - ${rem(32)})`,
+    maxWidth: '80vw',
+    width: 'fit-content',
   },
 }));
 
@@ -485,13 +518,16 @@ export const NotePopupDivider = styled('hr')(({ theme }) => ({
   margin: 0,
 }));
 
-// Second line: full note text — wraps naturally, no truncation
+// Second line: full note text — wraps naturally, no truncation, scrolls if needed
 export const NotePopupNoteText = styled(Typography)(({ theme }) => ({
   fontSize: rem(13),
   color: theme.palette.text.secondary,
   lineHeight: 1.5,
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
+  overflowY: 'auto',
+  maxHeight: `calc(80vh - ${rem(60)})`,
+  boxSizing: 'border-box',
 }));
 
 export const AllStepCircle = styled(StepCircle)(() => ({

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/JobWorkLogsTab.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { CircularProgress, Tooltip, IconButton } from '@mui/material';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import AddIcon from '@mui/icons-material/Add';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import SearchIcon from '@mui/icons-material/Search';
 import type {
   JobResponse,
   JobWorkflowStepResponse,
@@ -17,7 +13,6 @@ import { Loader } from '../../../../../components/UI/Loader/Loader';
 import { Button } from '../../../../../components/UI/Button';
 import { AddWorkLogModal } from './AddWorkLogModal';
 import { getStepColor } from './StepActivityTab.utils';
-import { rem } from '../../../../../components/UI/Typography/utility';
 import * as WS from './JobWorkLogsTab.styles';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -73,8 +68,6 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [popupLog, setPopupLog] = useState<StepVisitLogResponse | null>(null);
-  // Vertical centre (px from viewport top) of the row that was clicked
-  const [popupY, setPopupY] = useState<number>(0);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -220,12 +213,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
   // ── Modal helpers ────────────────────────────────────────────────────────────
 
   const handleRowClick = useCallback(
-    (log: StepVisitLogResponse, e: React.MouseEvent<HTMLTableRowElement>) => {
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const rawY = rect.top + rect.height / 2;
-      // Clamp so the popup card (est. ~100px tall) never overflows the viewport
-      const clampedY = Math.max(60, Math.min(rawY, window.innerHeight - 60));
-      setPopupY(clampedY);
+    (log: StepVisitLogResponse) => {
       setPopupLog(log);
     },
     []
@@ -269,10 +257,10 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
 
   if (!steps.length) {
     return (
-      <WS.EmptyFeedBox sx={{ minHeight: 300 }}>
-        <AccessTimeIcon sx={{ fontSize: rem(48), color: 'grey.200' }} />
+      <WS.WorkLogsEmptyFeedBox>
+        <WS.EmptyFeedIcon />
         <span>No workflow steps found for this job.</span>
-      </WS.EmptyFeedBox>
+      </WS.WorkLogsEmptyFeedBox>
     );
   }
 
@@ -289,13 +277,12 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
           {/* Search icon + expanding input */}
           <WS.StepSearchWrapper>
             <Tooltip title={searchOpen ? 'Close' : 'Jump to step'} placement="right">
-              <IconButton
+              <WS.JumpToStepButton
                 size="medium"
                 onClick={handleSearchIconClick}
-                sx={{ width: rem(32), height: rem(32), padding: 0 }}
               >
-                <SearchIcon sx={{ fontSize: rem(20) }} />
-              </IconButton>
+                <WS.SearchStepIcon />
+              </WS.JumpToStepButton>
             </Tooltip>
 
             {searchOpen && (
@@ -368,7 +355,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
         <WS.SummarySection>
           <WS.TrackingBox>
             <WS.TimerIconBox>
-              <AccessTimeIcon sx={{ fontSize: rem(32), color: 'white' }} />
+              <WS.TimerIcon />
             </WS.TimerIconBox>
             <WS.TrackingInfo>
               <WS.TrackingLabel>
@@ -447,7 +434,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                     /* Data row — clicking anywhere opens the popup */
                     <WS.DataTr
                       key={log.id}
-                      onClick={(e) => handleRowClick(log, e)}
+                      onClick={() => handleRowClick(log)}
                     >
                       <WS.Td>{formatDate(log.visitDate)}</WS.Td>
 
@@ -487,7 +474,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                               size="small"
                               onClick={() => openModal(log)}
                             >
-                              <EditIcon sx={{ fontSize: rem(16) }} />
+                              <WS.ActionEditIcon />
                             </IconButton>
                           </Tooltip>
                           <Tooltip title="Delete">
@@ -496,7 +483,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
                               color="error"
                               onClick={() => log.id && handleDelete(log.id)}
                             >
-                              <DeleteIcon sx={{ fontSize: rem(16) }} />
+                              <WS.ActionDeleteIcon />
                             </IconButton>
                           </Tooltip>
                         </WS.ActionCell>
@@ -515,7 +502,7 @@ export const JobWorkLogsTab: React.FC<JobWorkLogsTabProps> = ({ job }) => {
         /* Backdrop — click outside to close */
         <WS.NotePopupBackdrop onClick={() => setPopupLog(null)}>
           {/* Card — stop propagation so clicking inside doesn't close */}
-          <WS.NotePopupCard yOffset={popupY} onClick={(e) => e.stopPropagation()}>
+          <WS.NotePopupCard onClick={(e) => e.stopPropagation()}>
 
             {/* Line 1: start→end time + ✕ close button */}
             <WS.NotePopupHeader>

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.styles.ts
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.styles.ts
@@ -1,6 +1,13 @@
-import { Box, Typography, TextField, styled } from '@mui/material';
+import { Box, Typography, TextField, styled, IconButton } from '@mui/material';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { rem, Bold } from '../../../../../components/UI/Typography/utility';
 import { floowColors } from '../../../../../theme/colors';
+import { Button } from '../../../../../components/UI/Button';
 
 // ─── Layout ───────────────────────────────────────────────────────────────────
 
@@ -466,6 +473,7 @@ export const MessageBubble = styled(Box, {
   fontSize: rem(13.5),
   lineHeight: 1.65,
   wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap',
   '& p': { margin: 0 },
   '& strong': { fontWeight: Bold._700 },
 }));
@@ -576,4 +584,56 @@ export const FilterTypeLabel = styled(Typography)(({ theme }) => ({
   fontSize: rem(14),
   fontWeight: theme.typography.fontWeightMedium,
   letterSpacing: '0.3px',
+}));
+
+// Styled components to eliminate inline sx props in TSX
+export const ActivityEmptyFeedBox = styled(EmptyFeedBox)(() => ({
+  minHeight: rem(300),
+}));
+
+export const EmptyFeedIcon = styled(ChatBubbleOutlineIcon)(({ theme }) => ({
+  fontSize: rem(48),
+  color: theme.palette.colors.grey_200,
+}));
+
+export const CheckIconStyled = styled(CheckIcon)(() => ({
+  fontSize: rem(14),
+}));
+
+export const CloseIconStyled = styled(CloseIcon)(() => ({
+  fontSize: rem(14),
+}));
+
+export const DownloadIconButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== 'isMine',
+})<{ isMine?: boolean }>(({ isMine, theme }) => ({
+  color: isMine ? 'rgba(255, 255, 255, 0.8)' : theme.palette.text.secondary,
+}));
+
+export const MessageEditIcon = styled(EditIcon)(() => ({
+  fontSize: rem(13),
+}));
+
+export const MessageDeleteIcon = styled(DeleteIcon)(() => ({
+  fontSize: rem(13),
+}));
+
+export const SidebarEmptyIcon = styled(ChatBubbleOutlineIcon)(() => ({
+  fontSize: rem(14),
+}));
+
+export const HeaderEmptyIcon = styled(ChatBubbleOutlineIcon)(() => ({
+  fontSize: rem(15),
+}));
+
+export const AttachIconStyled = styled(AttachFileIcon)(() => ({
+  fontSize: rem(16),
+}));
+
+export const SendButton = styled(Button)(({ theme }) => ({
+  flexShrink: 0,
+  borderRadius: rem(10),
+  height: rem(40),
+  paddingLeft: theme.spacing(2.5),
+  paddingRight: theme.spacing(2.5),
 }));

--- a/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.tsx
+++ b/src/pages/jobs/components/JobDetailsTabs/tabs/StepActivityTab.tsx
@@ -1,18 +1,11 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import {
   Tooltip,
-  IconButton as MuiIconButton,
   CircularProgress,
   Typography,
 } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import CheckIcon from '@mui/icons-material/Check';
-import CloseIcon from '@mui/icons-material/Close';
 import { StandaloneDropdown } from '../../../../../components/UI/Forms/Dropdown';
 import SendIcon from '@mui/icons-material/Send';
-import AttachFileIcon from '@mui/icons-material/AttachFile';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import DownloadIcon from '@mui/icons-material/Download';
 import FilterListIcon from '@mui/icons-material/FilterList';
 
@@ -36,6 +29,7 @@ import {
   useGlobalModalOuterContext,
   ModalSizes,
 } from '../../../../../components/UI/GlobalModal';
+import { rem } from '../../../../../components/UI/Typography/utility';
 
 import { FilterByTypeScreen } from './FilterByTypeScreen';
 import * as SS from './StepActivityTab.styles';
@@ -323,8 +317,8 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
     if (!visibleItems.length) {
       return (
         <SS.EmptyFeedBox>
-          <ChatBubbleOutlineIcon sx={{ fontSize: 48, color: 'grey.200' }} />
-          <Typography fontSize={14} color="text.secondary">
+          <SS.EmptyFeedIcon />
+          <Typography fontSize={rem(14)} color="text.secondary">
             No activity yet. Start the discussion!
           </Typography>
         </SS.EmptyFeedBox>
@@ -396,12 +390,12 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                     <SS.MessageEditIconBtn onClick={saveEdit} disabled={savingEdit}>
                       {savingEdit
                         ? <CircularProgress size={12} />
-                        : <CheckIcon sx={{ fontSize: 14 }} />}
+                        : <SS.CheckIconStyled />}
                     </SS.MessageEditIconBtn>
                   </Tooltip>
                   <Tooltip title="Cancel (Esc)">
                     <SS.MessageEditIconBtn onClick={cancelEdit} disabled={savingEdit}>
-                      <CloseIcon sx={{ fontSize: 14 }} />
+                      <SS.CloseIconStyled />
                     </SS.MessageEditIconBtn>
                   </Tooltip>
                 </SS.MessageEditActions>
@@ -415,13 +409,13 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                     <SS.AttachmentFileName isMine={isMine}>{fileName}</SS.AttachmentFileName>
                     {item.fileUrl && (
                       <Tooltip title="Download">
-                        <MuiIconButton
+                        <SS.DownloadIconButton
                           size="small"
                           onClick={() => window.open(item.fileUrl, '_blank')}
-                          sx={{ color: isMine ? 'rgba(255,255,255,0.8)' : 'text.secondary' }}
+                          isMine={isMine}
                         >
                           <DownloadIcon fontSize="small" />
-                        </MuiIconButton>
+                        </SS.DownloadIconButton>
                       </Tooltip>
                     )}
                   </SS.AttachmentRow>
@@ -441,7 +435,7 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
             <SS.MessageActionGroup className="msg-action-group">
               <Tooltip title="Edit message">
                 <SS.MessageEditIconBtn onClick={() => startEdit(item)}>
-                  <EditIcon sx={{ fontSize: 13 }} />
+                  <SS.MessageEditIcon />
                 </SS.MessageEditIconBtn>
               </Tooltip>
               <Tooltip title="Delete message">
@@ -451,7 +445,7 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                 >
                   {isDeleting
                     ? <CircularProgress size={12} color="error" />
-                    : <DeleteIcon sx={{ fontSize: 13 }} />}
+                    : <SS.MessageDeleteIcon />}
                 </SS.MessageDeleteIconBtn>
               </Tooltip>
             </SS.MessageActionGroup>
@@ -469,11 +463,11 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
 
   if (!steps.length) {
     return (
-      <SS.EmptyFeedBox sx={{ minHeight: 300 }}>
-        <Typography color="text.secondary" fontSize={14}>
+      <SS.ActivityEmptyFeedBox>
+        <Typography color="text.secondary" fontSize={rem(14)}>
           No workflow steps found for this job.
         </Typography>
-      </SS.EmptyFeedBox>
+      </SS.ActivityEmptyFeedBox>
     );
   }
 
@@ -495,7 +489,7 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
               <SS.StepCircleIcon
                 circleColor={viewFilter === 'all' ? undefined : undefined}
               >
-                <ChatBubbleOutlineIcon sx={{ fontSize: 14 }} />
+                <SS.SidebarEmptyIcon />
               </SS.StepCircleIcon>
               <SS.StepTextGroup>
                 <SS.StepNameText isActive={viewFilter === 'all'}>All Steps</SS.StepNameText>
@@ -543,7 +537,7 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                 {activeStepIdx >= 0 ? (
                   activeStepIdx + 1
                 ) : (
-                  <ChatBubbleOutlineIcon sx={{ fontSize: 15 }} />
+                  <SS.HeaderEmptyIcon />
                 )}
               </SS.ChatHeaderCircle>
               <div>
@@ -591,7 +585,7 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                 {uploading ? (
                   <CircularProgress size={14} />
                 ) : (
-                  <AttachFileIcon sx={{ fontSize: 16 }} />
+                  <SS.AttachIconStyled />
                 )}
                 Attach
               </SS.ToolbarActionButton>
@@ -635,15 +629,14 @@ export const StepActivityTab: React.FC<StepActivityTabProps> = ({ job }) => {
                 maxRows={4}
                 fullWidth
               />
-              <Button
+              <SS.SendButton
                 size="medium"
                 onClick={handleSend}
                 disabled={!message.trim() || sending || !postToStepId}
                 endIcon={<SendIcon />}
-                sx={{ flexShrink: 0, borderRadius: '10px', height: 40, px: 2.5 }}
               >
                 {sending ? 'Sending…' : 'Send'}
-              </Button>
+              </SS.SendButton>
             </SS.InputRow>
           </SS.InputAreaWrapper>
         </SS.ChatPanel>


### PR DESCRIPTION
- Clamp worklog detail popup to max 80% viewport width/height and add vertical scrolling.
- Apply white-space: pre-wrap to step activity messages and comments to render newlines.
- Remove inline sx props and migrate styling to stylesheets using rem units.